### PR TITLE
datalog components parser helper and authorization helper

### DIFF
--- a/src/main/java/org/biscuitsec/biscuit/token/Authorizer.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/Authorizer.java
@@ -4,6 +4,7 @@ import static io.vavr.API.Left;
 import static io.vavr.API.Right;
 
 import io.vavr.Tuple2;
+import io.vavr.Tuple4;
 import io.vavr.control.Either;
 import io.vavr.control.Option;
 import java.time.Instant;
@@ -201,6 +202,32 @@ public final class Authorizer {
     this.token = token;
     updateOnToken();
     return this;
+  }
+
+  public Either<Map<Integer, List<Error>>, Authorizer> addDatalog(String s) {
+    Either<Map<Integer, List<org.biscuitsec.biscuit.token.builder.parser.Error>>, Tuple4<List<org.biscuitsec.biscuit.token.builder.Fact>, List<org.biscuitsec.biscuit.token.builder.Rule>, List<org.biscuitsec.biscuit.token.builder.Check>, List<org.biscuitsec.biscuit.token.builder.Scope>>> result = Parser
+        .datalogComponents(s);
+
+    if (result.isLeft()) {
+      Map<Integer, List<org.biscuitsec.biscuit.token.builder.parser.Error>> errors = result.getLeft();
+      Map<Integer, List<Error>> errorMap = new HashMap<>();
+      for (Map.Entry<Integer, List<org.biscuitsec.biscuit.token.builder.parser.Error>> entry : errors.entrySet()) {
+        List<Error> errorsList = new ArrayList<>();
+        for (org.biscuitsec.biscuit.token.builder.parser.Error error : entry.getValue()) {
+          errorsList.add(new Error.Parser(error));
+        }
+        errorMap.put(entry.getKey(), errorsList);
+      }
+      return Either.left(errorMap);
+    }
+
+    Tuple4<List<org.biscuitsec.biscuit.token.builder.Fact>, List<org.biscuitsec.biscuit.token.builder.Rule>, List<org.biscuitsec.biscuit.token.builder.Check>, List<org.biscuitsec.biscuit.token.builder.Scope>> components = result
+        .get();
+    components._1.forEach(this::addFact);
+    components._2.forEach(this::addRule);
+    components._3.forEach(this::addCheck);
+
+    return Either.right(this);
   }
 
   public Authorizer addFact(org.biscuitsec.biscuit.token.builder.Fact fact) {

--- a/src/main/java/org/biscuitsec/biscuit/token/builder/parser/Parser.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/builder/parser/Parser.java
@@ -34,16 +34,19 @@ public final class Parser {
    *
    * <p>If one succeeds it returns Right(Block) else it returns a Map[lineNumber, List[Error]]
    *
-   * @param index block index
    * @param s datalog string to parse
-   * @return Either<Map<Integer, List<Error>>, Block>
+   * @return Either<Map<Integer, List<Error>>, Tuple4<List<Fact>, List<Rule>,
+   *         List<Check>, List<Scope>>>
    */
-  public static Either<Map<Integer, List<Error>>, Block> datalog(long index, String s) {
-    Block blockBuilder = new Block();
+  public static Either<Map<Integer, List<Error>>, Tuple4<List<Fact>, List<Rule>, List<Check>, List<Scope>>> datalogComponents(
+      String s) {
+    List<Fact> facts = new ArrayList<>();
+    List<Rule> rules = new ArrayList<>();
+    List<Check> checks = new ArrayList<>();
+    List<Scope> scopes = new ArrayList<>();
 
-    // empty block code
     if (s.isEmpty()) {
-      return Either.right(blockBuilder);
+      return Either.right(new Tuple4<>(facts, rules, checks, scopes));
     }
 
     Map<Integer, List<Error>> errors = new HashMap<>();
@@ -61,58 +64,54 @@ public final class Parser {
                 List<Error> lineErrors = new ArrayList<>();
 
                 boolean parsed = false;
-                parsed =
-                    rule(code)
-                        .fold(
-                            e -> {
-                              lineErrors.add(e);
-                              return false;
-                            },
-                            r -> {
-                              blockBuilder.addRule(r._2);
-                              return true;
-                            });
+                parsed = rule(code)
+                    .fold(
+                        e -> {
+                          lineErrors.add(e);
+                          return false;
+                        },
+                        r -> {
+                          rules.add(r._2);
+                          return true;
+                        });
 
                 if (!parsed) {
-                  parsed =
-                      fact(code)
-                          .fold(
-                              e -> {
-                                lineErrors.add(e);
-                                return false;
-                              },
-                              r -> {
-                                blockBuilder.addFact(r._2);
-                                return true;
-                              });
+                  parsed = fact(code)
+                      .fold(
+                          e -> {
+                            lineErrors.add(e);
+                            return false;
+                          },
+                          r -> {
+                            facts.add(r._2);
+                            return true;
+                          });
                 }
 
                 if (!parsed) {
-                  parsed =
-                      check(code)
-                          .fold(
-                              e -> {
-                                lineErrors.add(e);
-                                return false;
-                              },
-                              r -> {
-                                blockBuilder.addCheck(r._2);
-                                return true;
-                              });
+                  parsed = check(code)
+                      .fold(
+                          e -> {
+                            lineErrors.add(e);
+                            return false;
+                          },
+                          r -> {
+                            checks.add(r._2);
+                            return true;
+                          });
                 }
 
                 if (!parsed) {
-                  parsed =
-                      scope(code)
-                          .fold(
-                              e -> {
-                                lineErrors.add(e);
-                                return false;
-                              },
-                              r -> {
-                                blockBuilder.addScope(r._2);
-                                return true;
-                              });
+                  parsed = scope(code)
+                      .fold(
+                          e -> {
+                            lineErrors.add(e);
+                            return false;
+                          },
+                          r -> {
+                            scopes.add(r._2);
+                            return true;
+                          });
                 }
 
                 if (!parsed) {
@@ -126,6 +125,39 @@ public final class Parser {
     if (!errors.isEmpty()) {
       return Either.left(errors);
     }
+
+    return Either.right(new Tuple4<>(facts, rules, checks, scopes));
+  }
+
+  /**
+   * Takes a datalog string with <code>\n</code> as datalog line separator. It
+   * tries to parse each
+   * line using fact, rule, check and scope sequentially.
+   *
+   * <p>
+   * If one succeeds it returns Right(Block) else it returns a Map[lineNumber,
+   * List[Error]]
+   *
+   * @param index block index
+   * @param s     datalog string to parse
+   * @return Either<Map<Integer, List<Error>>, Block>
+   */
+  public static Either<Map<Integer, List<Error>>, Block> datalog(long index, String s) {
+    Block blockBuilder = new Block();
+
+    Either<Map<Integer, List<Error>>, Tuple4<List<Fact>, List<Rule>, List<Check>, List<Scope>>> result = datalogComponents(
+        s);
+
+    if (result.isLeft()) {
+      return Either.left(result.getLeft());
+    }
+
+    Tuple4<List<Fact>, List<Rule>, List<Check>, List<Scope>> components = result.get();
+
+    components._1.forEach(blockBuilder::addFact);
+    components._2.forEach(blockBuilder::addRule);
+    components._3.forEach(blockBuilder::addCheck);
+    components._4.forEach(blockBuilder::addScope);
 
     return Either.right(blockBuilder);
   }

--- a/src/test/java/org/biscuitsec/biscuit/token/AuthorizerTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/AuthorizerTest.java
@@ -1,6 +1,8 @@
 package org.biscuitsec.biscuit.token;
 
 import static org.biscuitsec.biscuit.token.builder.Utils.constrainedRule;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import biscuit.format.schema.Schema;
@@ -71,6 +73,33 @@ public class AuthorizerTest {
     assertEquals(
         Set.of(new Term.Integer(1), new Term.Integer(2), new Term.Integer(3)),
         ((Term.Set) permsTerm).getValue());
+  }
+
+  @Test
+  public void testDatalogAuthorizer() throws Exception {
+    KeyPair keypair = KeyPair.generate(Schema.PublicKey.Algorithm.Ed25519, new SecureRandom());
+
+    Biscuit token = Biscuit.builder(keypair)
+        .addAuthorityFact("email(\"bob@example.com\")")
+        .addAuthorityFact("id(123)")
+        .addAuthorityFact("enabled(true)")
+        .addAuthorityFact("perms([1,2,3])")
+        .build();
+
+    Authorizer authorizer = Biscuit.fromBase64Url(token.serializeBase64Url(), keypair.getPublicKey())
+        .verify(keypair.getPublicKey())
+        .authorizer();
+
+    String l0 = "right($email) <- email($email)";
+    String l1 = "check if right(\"bob@example.com\")";
+    String datalog = String.join(";", Arrays.asList(l0, l1));
+    authorizer.addDatalog(datalog);
+    authorizer.addPolicy("allow if true");
+
+    assertDoesNotThrow(() -> authorizer.authorize());
+
+    Term emailTerm = queryFirstResult(authorizer, "right($address) <- email($address)");
+    assertEquals("bob@example.com", ((Term.Str) emailTerm).getValue());
   }
 
   private static Term queryFirstResult(Authorizer authorizer, String query) throws Error {


### PR DESCRIPTION
# Add string-based Datalog parsing support

## Changes:
1. **Authorizer.java**: Add a new `addDatalog` method to support parsing and adding Datalog components from a string
2. **Parser.java**: Refactor the `datalog` method into `datalogComponents` to support parsing Datalog strings into separate components (facts, rules, checks, scopes)

This change enables more straightforward Authorizer creation through string-based input, improving usability and testing capabilities.