### PR TITLE
datalog components parser helper and authorization helper

### DIFF
--- a/src/main/java/org/biscuitsec/biscuit/datalog/Combinator.java
+++ b/src/main/java/org/biscuitsec/biscuit/datalog/Combinator.java
@@ -119,7 +119,10 @@ public final class Combinator implements Serializable, Iterator<Tuple2<Origin, M
               // no need to copy all the expressions at all levels
               this.currentIt =
                   new Combinator(
-                      vars, predicates.subList(1, predicates.size()), this.allFacts, this.symbolTable);
+                      vars,
+                      predicates.subList(1, predicates.size()),
+                      this.allFacts,
+                      this.symbolTable);
             }
             break;
 

--- a/src/main/java/org/biscuitsec/biscuit/datalog/MatchedVariables.java
+++ b/src/main/java/org/biscuitsec/biscuit/datalog/MatchedVariables.java
@@ -64,8 +64,8 @@ public final class MatchedVariables implements Serializable {
     }
   }
 
-  public Option<Map<Long, Term>> checkExpressions(List<Expression> expressions, SymbolTable symbolTable)
-      throws Error {
+  public Option<Map<Long, Term>> checkExpressions(
+      List<Expression> expressions, SymbolTable symbolTable) throws Error {
     final Option<Map<Long, Term>> vars = this.complete();
     if (vars.isDefined()) {
       Map<Long, Term> variables = vars.get();

--- a/src/main/java/org/biscuitsec/biscuit/datalog/Rule.java
+++ b/src/main/java/org/biscuitsec/biscuit/datalog/Rule.java
@@ -127,7 +127,8 @@ public final class Rule implements Serializable {
 
   // do not produce new facts, only find one matching set of facts
   public boolean findMatch(
-      final FactSet facts, Long origin, TrustedOrigins scope, SymbolTable symbolTable) throws Error {
+      final FactSet facts, Long origin, TrustedOrigins scope, SymbolTable symbolTable)
+      throws Error {
     MatchedVariables variables = variablesSet();
 
     if (this.body.isEmpty()) {
@@ -135,7 +136,8 @@ public final class Rule implements Serializable {
     }
 
     Supplier<Stream<Tuple2<Origin, Fact>>> factsSupplier = () -> facts.stream(scope);
-    Stream<Either<Error, Tuple2<Origin, Fact>>> stream = this.apply(factsSupplier, origin, symbolTable);
+    Stream<Either<Error, Tuple2<Origin, Fact>>> stream =
+        this.apply(factsSupplier, origin, symbolTable);
 
     Iterator<Either<Error, Tuple2<Origin, Fact>>> it = stream.iterator();
 

--- a/src/main/java/org/biscuitsec/biscuit/datalog/World.java
+++ b/src/main/java/org/biscuitsec/biscuit/datalog/World.java
@@ -90,13 +90,14 @@ public final class World implements Serializable {
     return this.rules;
   }
 
-  public FactSet queryRule(final Rule rule, Long origin, TrustedOrigins scope, SymbolTable symbolTable)
-      throws Error {
+  public FactSet queryRule(
+      final Rule rule, Long origin, TrustedOrigins scope, SymbolTable symbolTable) throws Error {
     final FactSet newFacts = new FactSet();
 
     Supplier<Stream<Tuple2<Origin, Fact>>> factsSupplier = () -> this.facts.stream(scope);
 
-    Stream<Either<Error, Tuple2<Origin, Fact>>> stream = rule.apply(factsSupplier, origin, symbolTable);
+    Stream<Either<Error, Tuple2<Origin, Fact>>> stream =
+        rule.apply(factsSupplier, origin, symbolTable);
     for (Iterator<Either<Error, Tuple2<Origin, Fact>>> it = stream.iterator(); it.hasNext(); ) {
       Either<Error, Tuple2<Origin, Fact>> res = it.next();
 
@@ -111,8 +112,8 @@ public final class World implements Serializable {
     return newFacts;
   }
 
-  public boolean queryMatch(final Rule rule, Long origin, TrustedOrigins scope, SymbolTable symbolTable)
-      throws Error {
+  public boolean queryMatch(
+      final Rule rule, Long origin, TrustedOrigins scope, SymbolTable symbolTable) throws Error {
     return rule.findMatch(this.facts, origin, scope, symbolTable);
   }
 

--- a/src/main/java/org/biscuitsec/biscuit/datalog/expressions/Op.java
+++ b/src/main/java/org/biscuitsec/biscuit/datalog/expressions/Op.java
@@ -52,7 +52,8 @@ public abstract class Op {
     }
 
     @Override
-    public void evaluate(Deque<Term> stack, Map<Long, Term> variables, TemporarySymbolTable temporarySymbolTable)
+    public void evaluate(
+        Deque<Term> stack, Map<Long, Term> variables, TemporarySymbolTable temporarySymbolTable)
         throws Error.Execution {
       if (value instanceof Term.Variable) {
         Term.Variable var = (Term.Variable) value;
@@ -126,7 +127,8 @@ public abstract class Op {
     }
 
     @Override
-    public void evaluate(Deque<Term> stack, Map<Long, Term> variables, TemporarySymbolTable temporarySymbolTable)
+    public void evaluate(
+        Deque<Term> stack, Map<Long, Term> variables, TemporarySymbolTable temporarySymbolTable)
         throws Error.Execution {
       Term value = stack.pop();
       switch (this.op) {
@@ -287,7 +289,8 @@ public abstract class Op {
     }
 
     @Override
-    public void evaluate(Deque<Term> stack, Map<Long, Term> variables, TemporarySymbolTable temporarySymbolTable)
+    public void evaluate(
+        Deque<Term> stack, Map<Long, Term> variables, TemporarySymbolTable temporarySymbolTable)
         throws Error.Execution {
       Term right = stack.pop();
       Term left = stack.pop();
@@ -398,7 +401,8 @@ public abstract class Op {
           }
           if (left instanceof Term.Str && right instanceof Term.Str) {
             Option<String> leftS = temporarySymbolTable.getSymbol((int) ((Term.Str) left).value());
-            Option<String> rightS = temporarySymbolTable.getSymbol((int) ((Term.Str) right).value());
+            Option<String> rightS =
+                temporarySymbolTable.getSymbol((int) ((Term.Str) right).value());
 
             if (leftS.isEmpty()) {
               throw new Error.Execution(
@@ -415,7 +419,8 @@ public abstract class Op {
         case Prefix:
           if (right instanceof Term.Str && left instanceof Term.Str) {
             Option<String> leftS = temporarySymbolTable.getSymbol((int) ((Term.Str) left).value());
-            Option<String> rightS = temporarySymbolTable.getSymbol((int) ((Term.Str) right).value());
+            Option<String> rightS =
+                temporarySymbolTable.getSymbol((int) ((Term.Str) right).value());
             if (leftS.isEmpty()) {
               throw new Error.Execution(
                   "cannot find string in symbols for index " + ((Term.Str) left).value());
@@ -431,7 +436,8 @@ public abstract class Op {
         case Suffix:
           if (right instanceof Term.Str && left instanceof Term.Str) {
             Option<String> leftS = temporarySymbolTable.getSymbol((int) ((Term.Str) left).value());
-            Option<String> rightS = temporarySymbolTable.getSymbol((int) ((Term.Str) right).value());
+            Option<String> rightS =
+                temporarySymbolTable.getSymbol((int) ((Term.Str) right).value());
             if (leftS.isEmpty()) {
               throw new Error.Execution(
                   "cannot find string in symbols for index " + ((Term.Str) left).value());
@@ -446,7 +452,8 @@ public abstract class Op {
         case Regex:
           if (right instanceof Term.Str && left instanceof Term.Str) {
             Option<String> leftS = temporarySymbolTable.getSymbol((int) ((Term.Str) left).value());
-            Option<String> rightS = temporarySymbolTable.getSymbol((int) ((Term.Str) right).value());
+            Option<String> rightS =
+                temporarySymbolTable.getSymbol((int) ((Term.Str) right).value());
             if (leftS.isEmpty()) {
               throw new Error.Execution(
                   "cannot find string in symbols for index " + ((Term.Str) left).value());
@@ -474,7 +481,8 @@ public abstract class Op {
           }
           if (right instanceof Term.Str && left instanceof Term.Str) {
             Option<String> leftS = temporarySymbolTable.getSymbol((int) ((Term.Str) left).value());
-            Option<String> rightS = temporarySymbolTable.getSymbol((int) ((Term.Str) right).value());
+            Option<String> rightS =
+                temporarySymbolTable.getSymbol((int) ((Term.Str) right).value());
 
             if (leftS.isEmpty()) {
               throw new Error.Execution(

--- a/src/main/java/org/biscuitsec/biscuit/token/Authorizer.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/Authorizer.java
@@ -205,13 +205,22 @@ public final class Authorizer {
   }
 
   public Either<Map<Integer, List<Error>>, Authorizer> addDatalog(String s) {
-    Either<Map<Integer, List<org.biscuitsec.biscuit.token.builder.parser.Error>>, Tuple5<List<org.biscuitsec.biscuit.token.builder.Fact>, List<org.biscuitsec.biscuit.token.builder.Rule>, List<org.biscuitsec.biscuit.token.builder.Check>, List<org.biscuitsec.biscuit.token.builder.Scope>, List<Policy>>> result = Parser
-        .datalogComponents(s);
+    Either<
+            Map<Integer, List<org.biscuitsec.biscuit.token.builder.parser.Error>>,
+            Tuple5<
+                List<org.biscuitsec.biscuit.token.builder.Fact>,
+                List<org.biscuitsec.biscuit.token.builder.Rule>,
+                List<org.biscuitsec.biscuit.token.builder.Check>,
+                List<org.biscuitsec.biscuit.token.builder.Scope>,
+                List<Policy>>>
+        result = Parser.datalogComponents(s);
 
     if (result.isLeft()) {
-      Map<Integer, List<org.biscuitsec.biscuit.token.builder.parser.Error>> errors = result.getLeft();
+      Map<Integer, List<org.biscuitsec.biscuit.token.builder.parser.Error>> errors =
+          result.getLeft();
       Map<Integer, List<Error>> errorMap = new HashMap<>();
-      for (Map.Entry<Integer, List<org.biscuitsec.biscuit.token.builder.parser.Error>> entry : errors.entrySet()) {
+      for (Map.Entry<Integer, List<org.biscuitsec.biscuit.token.builder.parser.Error>> entry :
+          errors.entrySet()) {
         List<Error> errorsList = new ArrayList<>();
         for (org.biscuitsec.biscuit.token.builder.parser.Error error : entry.getValue()) {
           errorsList.add(new Error.Parser(error));
@@ -221,8 +230,13 @@ public final class Authorizer {
       return Either.left(errorMap);
     }
 
-    Tuple5<List<org.biscuitsec.biscuit.token.builder.Fact>, List<org.biscuitsec.biscuit.token.builder.Rule>, List<org.biscuitsec.biscuit.token.builder.Check>, List<org.biscuitsec.biscuit.token.builder.Scope>, List<Policy>> components = result
-        .get();
+    Tuple5<
+            List<org.biscuitsec.biscuit.token.builder.Fact>,
+            List<org.biscuitsec.biscuit.token.builder.Rule>,
+            List<org.biscuitsec.biscuit.token.builder.Check>,
+            List<org.biscuitsec.biscuit.token.builder.Scope>,
+            List<Policy>>
+        components = result.get();
     components._1.forEach(this::addFact);
     components._2.forEach(this::addRule);
     components._3.forEach(this::addCheck);
@@ -308,7 +322,8 @@ public final class Authorizer {
 
   public Authorizer setTime() throws Error.Language {
     world.addFact(
-        Origin.authorizer(), Utils.fact("time", List.of(Utils.date(new Date()))).convert(symbolTable));
+        Origin.authorizer(),
+        Utils.fact("time", List.of(Utils.date(new Date()))).convert(symbolTable));
     return this;
   }
 
@@ -683,7 +698,12 @@ public final class Authorizer {
 
         for (int j = 0; j < b.getChecks().size(); j++) {
           checks.add(
-              "Block[" + (i + 1) + "][" + j + "]: " + blockSymbolTable.formatCheck(b.getChecks().get(j)));
+              "Block["
+                  + (i + 1)
+                  + "]["
+                  + j
+                  + "]: "
+                  + blockSymbolTable.formatCheck(b.getChecks().get(j)));
         }
       }
     }
@@ -725,7 +745,8 @@ public final class Authorizer {
       List<Check> blockChecks = new ArrayList<>();
 
       if (block.getExternalKey().isDefined()) {
-        SymbolTable blockSymbolTable = new SymbolTable(block.getSymbolTable(), block.getPublicKeys());
+        SymbolTable blockSymbolTable =
+            new SymbolTable(block.getSymbolTable(), block.getPublicKeys());
         for (org.biscuitsec.biscuit.datalog.Check check : block.getChecks()) {
           blockChecks.add(Check.convertFrom(check, blockSymbolTable));
         }

--- a/src/main/java/org/biscuitsec/biscuit/token/Biscuit.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/Biscuit.java
@@ -241,7 +241,8 @@ public final class Biscuit extends UnverifiedBiscuit {
    * @param data
    * @return
    */
-  public static Biscuit fromBytesWithSymbols(byte[] data, KeyDelegate delegate, SymbolTable symbolTable)
+  public static Biscuit fromBytesWithSymbols(
+      byte[] data, KeyDelegate delegate, SymbolTable symbolTable)
       throws NoSuchAlgorithmException, SignatureException, InvalidKeyException, Error {
     // System.out.println("will deserialize and verify token");
     SerializedBiscuit ser = SerializedBiscuit.fromBytes(data, delegate);
@@ -255,7 +256,8 @@ public final class Biscuit extends UnverifiedBiscuit {
    *
    * @return
    */
-  static Biscuit fromSerializedBiscuit(SerializedBiscuit ser, SymbolTable symbolTable) throws Error {
+  static Biscuit fromSerializedBiscuit(SerializedBiscuit ser, SymbolTable symbolTable)
+      throws Error {
     Tuple2<Block, ArrayList<Block>> t = ser.extractBlocks(symbolTable);
     Block authority = t._1;
     ArrayList<Block> blocks = t._2;

--- a/src/main/java/org/biscuitsec/biscuit/token/Block.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/Block.java
@@ -485,7 +485,6 @@ public final class Block {
     return Collections.unmodifiableList(checks);
   }
 
-
   public List<PublicKey> getPublicKeys() {
     return Collections.unmodifiableList(this.publicKeys);
   }

--- a/src/main/java/org/biscuitsec/biscuit/token/UnverifiedBiscuit.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/UnverifiedBiscuit.java
@@ -87,8 +87,8 @@ public class UnverifiedBiscuit {
    *
    * @return UnverifiedBiscuit
    */
-  private static UnverifiedBiscuit fromSerializedBiscuit(SerializedBiscuit ser, SymbolTable symbolTable)
-      throws Error {
+  private static UnverifiedBiscuit fromSerializedBiscuit(
+      SerializedBiscuit ser, SymbolTable symbolTable) throws Error {
     Tuple2<Block, ArrayList<Block>> t = ser.extractBlocks(symbolTable);
     Block authority = t._1;
     ArrayList<Block> blocks = t._2;

--- a/src/main/java/org/biscuitsec/biscuit/token/builder/Expression.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/builder/Expression.java
@@ -9,7 +9,8 @@ import org.biscuitsec.biscuit.datalog.SymbolTable;
 
 public abstract class Expression {
 
-  public final org.biscuitsec.biscuit.datalog.expressions.Expression convert(SymbolTable symbolTable) {
+  public final org.biscuitsec.biscuit.datalog.expressions.Expression convert(
+      SymbolTable symbolTable) {
     ArrayList<org.biscuitsec.biscuit.datalog.expressions.Op> ops = new ArrayList<>();
     this.toOpcodes(symbolTable, ops);
 
@@ -162,8 +163,9 @@ public abstract class Expression {
     }
 
     public void toOpcodes(
-            SymbolTable symbolTable, List<org.biscuitsec.biscuit.datalog.expressions.Op> ops) {
-      ops.add(new org.biscuitsec.biscuit.datalog.expressions.Op.Value(this.value.convert(symbolTable)));
+        SymbolTable symbolTable, List<org.biscuitsec.biscuit.datalog.expressions.Op> ops) {
+      ops.add(
+          new org.biscuitsec.biscuit.datalog.expressions.Op.Value(this.value.convert(symbolTable)));
     }
 
     public void gatherVariables(Set<String> variables) {
@@ -207,7 +209,7 @@ public abstract class Expression {
     }
 
     public void toOpcodes(
-            SymbolTable symbolTable, List<org.biscuitsec.biscuit.datalog.expressions.Op> ops) {
+        SymbolTable symbolTable, List<org.biscuitsec.biscuit.datalog.expressions.Op> ops) {
       this.arg1.toOpcodes(symbolTable, ops);
 
       switch (this.op) {
@@ -286,7 +288,7 @@ public abstract class Expression {
     }
 
     public void toOpcodes(
-            SymbolTable symbolTable, List<org.biscuitsec.biscuit.datalog.expressions.Op> ops) {
+        SymbolTable symbolTable, List<org.biscuitsec.biscuit.datalog.expressions.Op> ops) {
       this.arg1.toOpcodes(symbolTable, ops);
       this.arg2.toOpcodes(symbolTable, ops);
 

--- a/src/main/java/org/biscuitsec/biscuit/token/builder/Scope.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/builder/Scope.java
@@ -67,7 +67,8 @@ public final class Scope {
     }
   }
 
-  public static Scope convertFrom(org.biscuitsec.biscuit.datalog.Scope scope, SymbolTable symbolTable) {
+  public static Scope convertFrom(
+      org.biscuitsec.biscuit.datalog.Scope scope, SymbolTable symbolTable) {
     switch (scope.kind()) {
       case Authority:
         return new Scope(Kind.Authority);
@@ -75,7 +76,8 @@ public final class Scope {
         return new Scope(Kind.Previous);
       case PublicKey:
         // FIXME error management should bubble up here
-        return new Scope(Kind.PublicKey, symbolTable.getPublicKey((int) scope.getPublicKey()).get());
+        return new Scope(
+            Kind.PublicKey, symbolTable.getPublicKey((int) scope.getPublicKey()).get());
       default:
         return null;
     }

--- a/src/main/java/org/biscuitsec/biscuit/token/builder/parser/Parser.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/builder/parser/Parser.java
@@ -2,8 +2,8 @@ package org.biscuitsec.biscuit.token.builder.parser;
 
 import biscuit.format.schema.Schema;
 import io.vavr.Tuple2;
-import io.vavr.Tuple5;
 import io.vavr.Tuple4;
+import io.vavr.Tuple5;
 import io.vavr.collection.Stream;
 import io.vavr.control.Either;
 import java.time.OffsetDateTime;
@@ -39,8 +39,10 @@ public final class Parser {
    * @return Either<Map<Integer, List<Error>>, Tuple5<List<Fact>, List<Rule>,
    *         List<Check>, List<Scope>, List<Policy>>>
    */
-  public static Either<Map<Integer, List<Error>>, Tuple5<List<Fact>, List<Rule>, List<Check>, List<Scope>, List<Policy>>> datalogComponents(
-      String s) {
+  public static Either<
+          Map<Integer, List<Error>>,
+          Tuple5<List<Fact>, List<Rule>, List<Check>, List<Scope>, List<Policy>>>
+      datalogComponents(String s) {
     List<Fact> facts = new ArrayList<>();
     List<Rule> rules = new ArrayList<>();
     List<Check> checks = new ArrayList<>();
@@ -66,67 +68,72 @@ public final class Parser {
                 List<Error> lineErrors = new ArrayList<>();
 
                 boolean parsed = false;
-                parsed = rule(code)
-                    .fold(
-                        e -> {
-                          lineErrors.add(e);
-                          return false;
-                        },
-                        r -> {
-                          rules.add(r._2);
-                          return true;
-                        });
+                parsed =
+                    rule(code)
+                        .fold(
+                            e -> {
+                              lineErrors.add(e);
+                              return false;
+                            },
+                            r -> {
+                              rules.add(r._2);
+                              return true;
+                            });
 
                 if (!parsed) {
-                  parsed = fact(code)
-                      .fold(
-                          e -> {
-                            lineErrors.add(e);
-                            return false;
-                          },
-                          r -> {
-                            facts.add(r._2);
-                            return true;
-                          });
+                  parsed =
+                      fact(code)
+                          .fold(
+                              e -> {
+                                lineErrors.add(e);
+                                return false;
+                              },
+                              r -> {
+                                facts.add(r._2);
+                                return true;
+                              });
                 }
 
                 if (!parsed) {
-                  parsed = check(code)
-                      .fold(
-                          e -> {
-                            lineErrors.add(e);
-                            return false;
-                          },
-                          r -> {
-                            checks.add(r._2);
-                            return true;
-                          });
+                  parsed =
+                      check(code)
+                          .fold(
+                              e -> {
+                                lineErrors.add(e);
+                                return false;
+                              },
+                              r -> {
+                                checks.add(r._2);
+                                return true;
+                              });
                 }
 
                 if (!parsed) {
-                  parsed = scope(code)
-                      .fold(
-                          e -> {
-                            lineErrors.add(e);
-                            return false;
-                          },
-                          r -> {
-                            scopes.add(r._2);
-                            return true;
-                          });
+                  parsed =
+                      scope(code)
+                          .fold(
+                              e -> {
+                                lineErrors.add(e);
+                                return false;
+                              },
+                              r -> {
+                                scopes.add(r._2);
+                                return true;
+                              });
                 }
 
                 if (!parsed) {
-                  parsed = policy(code)
-                      .fold(
-                          e -> {
-                            lineErrors.add(e);
-                            return false;
-                          },
-                          r -> {
-                            policies.add(r._2);
-                            return true;
-                          });
+                  parsed =
+                      policy(code)
+                          .fold(
+                              e -> {
+                                lineErrors.add(e);
+                                return false;
+                              },
+                              r -> {
+                                policies.add(r._2);
+                                return true;
+                              });
                 }
 
                 if (!parsed) {
@@ -160,14 +167,17 @@ public final class Parser {
   public static Either<Map<Integer, List<Error>>, Block> datalog(long index, String s) {
     Block blockBuilder = new Block();
 
-    Either<Map<Integer, List<Error>>, Tuple5<List<Fact>, List<Rule>, List<Check>, List<Scope>, List<Policy>>> result = datalogComponents(
-        s);
+    Either<
+            Map<Integer, List<Error>>,
+            Tuple5<List<Fact>, List<Rule>, List<Check>, List<Scope>, List<Policy>>>
+        result = datalogComponents(s);
 
     if (result.isLeft()) {
       return Either.left(result.getLeft());
     }
 
-    Tuple5<List<Fact>, List<Rule>, List<Check>, List<Scope>, List<Policy>> components = result.get();
+    Tuple5<List<Fact>, List<Rule>, List<Check>, List<Scope>, List<Policy>> components =
+        result.get();
 
     components._1.forEach(blockBuilder::addFact);
     components._2.forEach(blockBuilder::addRule);

--- a/src/main/java/org/biscuitsec/biscuit/token/builder/parser/Parser.java
+++ b/src/main/java/org/biscuitsec/biscuit/token/builder/parser/Parser.java
@@ -179,6 +179,16 @@ public final class Parser {
     Tuple5<List<Fact>, List<Rule>, List<Check>, List<Scope>, List<Policy>> components =
         result.get();
 
+    if (!components._5.isEmpty()) {
+      return Either.left(
+          Map.of(
+              -1, // we don't have a line number for policies
+              List.of(
+                  new Error(
+                      s,
+                      "Policies must be empty but found " + components._5.size() + " policies"))));
+    }
+
     components._1.forEach(blockBuilder::addFact);
     components._2.forEach(blockBuilder::addRule);
     components._3.forEach(blockBuilder::addCheck);

--- a/src/test/java/org/biscuitsec/biscuit/builder/parser/ParserTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/builder/parser/ParserTest.java
@@ -275,7 +275,7 @@ class ParserTest {
             new Tuple2<>(
                 "",
                 new Check(
-                        ONE,
+                    ONE,
                     Arrays.asList(
                         Utils.rule(
                             "query",

--- a/src/test/java/org/biscuitsec/biscuit/token/AuthorizerTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/AuthorizerTest.java
@@ -1,6 +1,8 @@
 package org.biscuitsec.biscuit.token;
 
 import static org.biscuitsec.biscuit.token.builder.Utils.constrainedRule;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import biscuit.format.schema.Schema;
@@ -71,6 +73,33 @@ public class AuthorizerTest {
     assertEquals(
         Set.of(new Term.Integer(1), new Term.Integer(2), new Term.Integer(3)),
         ((Term.Set) permsTerm).getValue());
+  }
+
+  @Test
+  public void testDatalogAuthorizer() throws Exception {
+    KeyPair keypair = KeyPair.generate(Schema.PublicKey.Algorithm.Ed25519, new SecureRandom());
+
+    Biscuit token = Biscuit.builder(keypair)
+        .addAuthorityFact("email(\"bob@example.com\")")
+        .addAuthorityFact("id(123)")
+        .addAuthorityFact("enabled(true)")
+        .addAuthorityFact("perms([1,2,3])")
+        .build();
+
+    Authorizer authorizer = Biscuit.fromBase64Url(token.serializeBase64Url(), keypair.getPublicKey())
+        .verify(keypair.getPublicKey())
+        .authorizer();
+
+    String l0 = "right($email) <- email($email)";
+    String l1 = "check if right(\"bob@example.com\")";
+    String l2 = "allow if true";
+    String datalog = String.join(";", Arrays.asList(l0, l1, l2));
+    authorizer.addDatalog(datalog);
+
+    assertDoesNotThrow(() -> authorizer.authorize());
+
+    Term emailTerm = queryFirstResult(authorizer, "right($address) <- email($address)");
+    assertEquals("bob@example.com", ((Term.Str) emailTerm).getValue());
   }
 
   private static Term queryFirstResult(Authorizer authorizer, String query) throws Error {

--- a/src/test/java/org/biscuitsec/biscuit/token/AuthorizerTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/AuthorizerTest.java
@@ -1,7 +1,6 @@
 package org.biscuitsec.biscuit.token;
 
 import static org.biscuitsec.biscuit.token.builder.Utils.constrainedRule;
-import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -79,16 +78,18 @@ public class AuthorizerTest {
   public void testDatalogAuthorizer() throws Exception {
     KeyPair keypair = KeyPair.generate(Schema.PublicKey.Algorithm.Ed25519, new SecureRandom());
 
-    Biscuit token = Biscuit.builder(keypair)
-        .addAuthorityFact("email(\"bob@example.com\")")
-        .addAuthorityFact("id(123)")
-        .addAuthorityFact("enabled(true)")
-        .addAuthorityFact("perms([1,2,3])")
-        .build();
+    Biscuit token =
+        Biscuit.builder(keypair)
+            .addAuthorityFact("email(\"bob@example.com\")")
+            .addAuthorityFact("id(123)")
+            .addAuthorityFact("enabled(true)")
+            .addAuthorityFact("perms([1,2,3])")
+            .build();
 
-    Authorizer authorizer = Biscuit.fromBase64Url(token.serializeBase64Url(), keypair.getPublicKey())
-        .verify(keypair.getPublicKey())
-        .authorizer();
+    Authorizer authorizer =
+        Biscuit.fromBase64Url(token.serializeBase64Url(), keypair.getPublicKey())
+            .verify(keypair.getPublicKey())
+            .authorizer();
 
     String l0 = "right($email) <- email($email)";
     String l1 = "check if right(\"bob@example.com\")";

--- a/src/test/java/org/biscuitsec/biscuit/token/BiscuitTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/BiscuitTest.java
@@ -25,12 +25,10 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-
 import org.biscuitsec.biscuit.crypto.KeyDelegate;
 import org.biscuitsec.biscuit.crypto.KeyPair;
 import org.biscuitsec.biscuit.crypto.PublicKey;
 import org.biscuitsec.biscuit.datalog.RunLimits;
-import org.biscuitsec.biscuit.datalog.SymbolTable;
 import org.biscuitsec.biscuit.error.Error;
 import org.biscuitsec.biscuit.error.FailedCheck;
 import org.biscuitsec.biscuit.error.LogicError;
@@ -82,7 +80,7 @@ public class BiscuitTest {
         check(
             rule(
                 "caveat1",
-                    List.of(var("resource")),
+                List.of(var("resource")),
                 Arrays.asList(
                     pred("resource", List.of(var("resource"))),
                     pred("operation", List.of(str("read"))),
@@ -115,8 +113,8 @@ public class BiscuitTest {
         check(
             rule(
                 "caveat2",
-                    List.of(str("file1")),
-                    List.of(pred("resource", List.of(str("file1")))))));
+                List.of(str("file1")),
+                List.of(pred("resource", List.of(str("file1")))))));
 
     Biscuit b3 = deser2.attenuate(rng, keypair3, builder3);
 
@@ -441,7 +439,7 @@ public class BiscuitTest {
         check(
             rule(
                 "caveat1",
-                    List.of(var("resource")),
+                List.of(var("resource")),
                 Arrays.asList(
                     pred("resource", List.of(var("resource"))),
                     pred("operation", List.of(str("read"))),
@@ -474,8 +472,8 @@ public class BiscuitTest {
         check(
             rule(
                 "caveat2",
-                    List.of(str("file1")),
-                    List.of(pred("resource", List.of(str("file1")))))));
+                List.of(str("file1")),
+                List.of(pred("resource", List.of(str("file1")))))));
 
     Biscuit b3 = deser2.attenuate(rng, keypair3, builder3);
 
@@ -571,7 +569,7 @@ public class BiscuitTest {
         check(
             rule(
                 "caveat1",
-                    List.of(var("resource")),
+                List.of(var("resource")),
                 Arrays.asList(
                     pred("resource", List.of(var("resource"))),
                     pred("operation", List.of(str("read"))),
@@ -604,8 +602,8 @@ public class BiscuitTest {
         check(
             rule(
                 "caveat2",
-                    List.of(str("file1")),
-                    List.of(pred("resource", List.of(str("file1")))))));
+                List.of(str("file1")),
+                List.of(pred("resource", List.of(str("file1")))))));
 
     Biscuit b3 = deser2.attenuate(rng, keypair3, builder3);
 
@@ -762,12 +760,12 @@ public class BiscuitTest {
           new Error.FailedLogic(
               new LogicError.Unauthorized(
                   new LogicError.MatchedPolicy.Allow(0),
-                      List.of(
-                              new FailedCheck.FailedBlock(
-                                      0,
-                                      0,
-                                      "check all operation($op), allowed_operations($allowed),"
-                                              + " $allowed.contains($op)")))),
+                  List.of(
+                      new FailedCheck.FailedBlock(
+                          0,
+                          0,
+                          "check all operation($op), allowed_operations($allowed),"
+                              + " $allowed.contains($op)")))),
           e);
     }
 

--- a/src/test/java/org/biscuitsec/biscuit/token/ExampleTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/ExampleTest.java
@@ -39,5 +39,4 @@ public class ExampleTest {
     Block block = token.createBlock().addCheck("check if operation(\"read\")");
     return token.attenuate(block, root.getPublicKey().getAlgorithm());
   }
-
 }

--- a/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/biscuitsec/biscuit/token/SamplesTest.java
@@ -173,8 +173,7 @@ class SamplesTest {
                           System.out.println(
                               Arrays.toString(token.serializedBiscuit.getAuthority().getBlock()));
                           org.biscuitsec.biscuit.token.Block deserBlockAuthority =
-                              fromBytes(serBlockAuthority, token.authority.getExternalKey())
-                                  .get();
+                              fromBytes(serBlockAuthority, token.authority.getExternalKey()).get();
                           assertEquals(
                               token.authority.print(token.symbolTable),
                               deserBlockAuthority.print(token.symbolTable));
@@ -189,7 +188,8 @@ class SamplesTest {
                             org.biscuitsec.biscuit.token.Block deserBlock =
                                 fromBytes(serBlock, block.getExternalKey()).get();
                             assertEquals(
-                                block.print(token.symbolTable), deserBlock.print(token.symbolTable));
+                                block.print(token.symbolTable),
+                                deserBlock.print(token.symbolTable));
                             assert (Arrays.equals(serBlock, signedBlock.getBlock()));
                           }
 
@@ -300,8 +300,10 @@ class SamplesTest {
   class Block {
     List<String> symbols;
     String code;
+
     @SuppressWarnings("checkstyle:MemberName")
     List<String> public_keys;
+
     @SuppressWarnings("checkstyle:MemberName")
     String external_key;
 
@@ -414,6 +416,7 @@ class SamplesTest {
 
     @SuppressWarnings("checkstyle:MemberName")
     String root_public_key;
+
     List<TestCase> testcases;
 
     @SuppressWarnings("checkstyle:MethodName")


### PR DESCRIPTION
# Add string-based Datalog parsing support

## Changes:
1. **Authorizer.java**: Add a new `addDatalog` method to support parsing and adding Datalog components from a string
2. **Parser.java**: Refactor the `datalog` method into `datalogComponents` to support parsing Datalog strings into separate components (facts, rules, checks, scopes)

This change enables more straightforward Authorizer creation through string-based input, improving usability and testing capabilities.