### PR TITLE
Updates to key accessors and fix proof algorithm type

### DIFF
--- a/src/main/java/org/eclipse/biscuit/token/Biscuit.java
+++ b/src/main/java/org/eclipse/biscuit/token/Biscuit.java
@@ -128,10 +128,9 @@ public final class Biscuit extends UnverifiedBiscuit {
       throw container.getLeft();
     } else {
       SerializedBiscuit s = container.get();
-      List<byte[]> revocationIds = s.revocationIdentifiers();
 
       Option<SerializedBiscuit> c = Option.some(s);
-      return new Biscuit(authority, blocks, authority.getSymbolTable(), s, revocationIds);
+      return new Biscuit(authority, blocks, authority.getSymbolTable(), s);
     }
   }
 
@@ -139,9 +138,8 @@ public final class Biscuit extends UnverifiedBiscuit {
       Block authority,
       List<Block> blocks,
       SymbolTable symbolTable,
-      SerializedBiscuit serializedBiscuit,
-      List<byte[]> revocationIds) {
-    super(authority, blocks, symbolTable, serializedBiscuit, revocationIds);
+      SerializedBiscuit serializedBiscuit) {
+    super(authority, blocks, symbolTable, serializedBiscuit);
   }
 
   /**
@@ -268,9 +266,7 @@ public final class Biscuit extends UnverifiedBiscuit {
     Block authority = t._1;
     ArrayList<Block> blocks = t._2;
 
-    List<byte[]> revocationIds = ser.revocationIdentifiers();
-
-    return new Biscuit(authority, blocks, symbolTable, ser, revocationIds);
+    return new Biscuit(authority, blocks, symbolTable, ser);
   }
 
   /**
@@ -365,9 +361,8 @@ public final class Biscuit extends UnverifiedBiscuit {
     blocks.add(block);
 
     SerializedBiscuit container = containerRes.get();
-    List<byte[]> revocationIds = container.revocationIdentifiers();
 
-    return new Biscuit(copiedBiscuit.authority, blocks, symbolTable, container, revocationIds);
+    return new Biscuit(copiedBiscuit.authority, blocks, symbolTable, container);
   }
 
   /** Generates a third party block request from a token */

--- a/src/main/java/org/eclipse/biscuit/token/UnverifiedBiscuit.java
+++ b/src/main/java/org/eclipse/biscuit/token/UnverifiedBiscuit.java
@@ -36,19 +36,16 @@ public class UnverifiedBiscuit {
   protected final List<Block> blocks;
   protected final SymbolTable symbolTable;
   protected final SerializedBiscuit serializedBiscuit;
-  protected final List<byte[]> revocationIds;
 
   UnverifiedBiscuit(
       Block authority,
       List<Block> blocks,
       SymbolTable symbolTable,
-      SerializedBiscuit serializedBiscuit,
-      List<byte[]> revocationIds) {
+      SerializedBiscuit serializedBiscuit) {
     this.authority = authority;
     this.blocks = blocks;
     this.symbolTable = symbolTable;
     this.serializedBiscuit = serializedBiscuit;
-    this.revocationIds = revocationIds;
   }
 
   /**
@@ -98,9 +95,7 @@ public class UnverifiedBiscuit {
     Block authority = t._1;
     ArrayList<Block> blocks = t._2;
 
-    List<byte[]> revocationIds = ser.revocationIdentifiers();
-
-    return new UnverifiedBiscuit(authority, blocks, symbolTable, ser, revocationIds);
+    return new UnverifiedBiscuit(authority, blocks, symbolTable, ser);
   }
 
   /**
@@ -189,16 +184,13 @@ public class UnverifiedBiscuit {
     blocks.add(block);
     SerializedBiscuit container = containerRes.get();
 
-    List<byte[]> revocationIds = container.revocationIdentifiers();
-
-    return new UnverifiedBiscuit(
-        copiedBiscuit.authority, blocks, symbols, container, revocationIds);
+    return new UnverifiedBiscuit(copiedBiscuit.authority, blocks, symbols, container);
   }
 
   // FIXME: attenuate 3rd Party
 
   public List<RevocationIdentifier> revocationIdentifiers() {
-    return this.revocationIds.stream()
+    return this.serializedBiscuit.revocationIdentifiers().stream()
         .map(RevocationIdentifier::fromBytes)
         .collect(Collectors.toList());
   }
@@ -304,9 +296,7 @@ public class UnverifiedBiscuit {
     }
     blocks.add(block);
 
-    List<byte[]> revocationIds = container.revocationIdentifiers();
-    return new UnverifiedBiscuit(
-        copiedBiscuit.authority, blocks, symbols, container, revocationIds);
+    return new UnverifiedBiscuit(copiedBiscuit.authority, blocks, symbols, container);
   }
 
   /** Prints a token's content */

--- a/src/main/java/org/eclipse/biscuit/token/format/SerializedBiscuit.java
+++ b/src/main/java/org/eclipse/biscuit/token/format/SerializedBiscuit.java
@@ -172,13 +172,18 @@ public final class SerializedBiscuit {
       throw new Error.FormatError.DeserializationError("invalid proof");
     }
 
-    final Proof proof =
-        data.getProof().hasFinalSignature()
-            ? new Proof.FinalSignature(data.getProof().getFinalSignature().toByteArray())
-            : new Proof.NextSecret(
-                KeyPair.generate(
-                    authority.getKey().getAlgorithm(),
-                    data.getProof().getNextSecret().toByteArray()));
+    final Proof proof;
+    if (data.getProof().hasFinalSignature()) {
+      proof = new Proof.FinalSignature(data.getProof().getFinalSignature().toByteArray());
+    } else {
+      final Schema.PublicKey.Algorithm proofAlgorithm =
+          blocks.isEmpty()
+              ? authority.getKey().getAlgorithm()
+              : blocks.get(blocks.size() - 1).getKey().getAlgorithm();
+      proof =
+          new Proof.NextSecret(
+              KeyPair.generate(proofAlgorithm, data.getProof().getNextSecret().toByteArray()));
+    }
 
     Option<Integer> rootKeyId =
         data.hasRootKeyId() ? Option.some(data.getRootKeyId()) : Option.none();

--- a/src/test/java/org/eclipse/biscuit/token/BiscuitTest.java
+++ b/src/test/java/org/eclipse/biscuit/token/BiscuitTest.java
@@ -72,6 +72,7 @@ public class BiscuitTest {
 
     System.out.println("deserializing the first token");
     Biscuit deser = Biscuit.fromBytes(data, root.getPublicKey());
+    assertEquals(1, deser.blockCount());
 
     System.out.println(deser.print());
 
@@ -105,6 +106,7 @@ public class BiscuitTest {
 
     System.out.println("deserializing the second token");
     Biscuit deser2 = Biscuit.fromBytes(data2, root.getPublicKey());
+    assertEquals(2, deser2.blockCount());
 
     System.out.println(deser2.print());
 
@@ -135,6 +137,7 @@ public class BiscuitTest {
 
     System.out.println("deserializing the third token");
     Biscuit finalToken = Biscuit.fromBytes(data3, root.getPublicKey());
+    assertEquals(3, finalToken.blockCount());
 
     System.out.println(finalToken.print());
 

--- a/src/test/java/org/eclipse/biscuit/token/ThirdPartyTest.java
+++ b/src/test/java/org/eclipse/biscuit/token/ThirdPartyTest.java
@@ -8,6 +8,7 @@ package org.eclipse.biscuit.token;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import biscuit.format.schema.Schema;
+import io.vavr.control.Option;
 import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -15,6 +16,7 @@ import java.security.SecureRandom;
 import java.security.SignatureException;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.List;
 import org.eclipse.biscuit.crypto.KeyPair;
 import org.eclipse.biscuit.datalog.RunLimits;
 import org.eclipse.biscuit.error.Error;
@@ -66,6 +68,10 @@ public class ThirdPartyTest {
     byte[] data = b2.serialize();
     Biscuit deser = Biscuit.fromBytes(data, root.getPublicKey());
     assertEquals(b2.print(), deser.print());
+    assertEquals(
+        b2.externalPublicKeys(), List.of(Option.none(), Option.of(external.getPublicKey())));
+    assertEquals(Option.none(), b2.blockExternalKey(0));
+    assertEquals(Option.of(external.getPublicKey()), b2.blockExternalKey(1));
 
     System.out.println("will check the token for resource=file1");
     Authorizer authorizer = deser.authorizer();


### PR DESCRIPTION
Changes are best reviewed commit-by-commit.

- Remove cached revocation identifiers from `UnverifiedBiscuit`.
- Augment `UnverifiedBiscuit` with external key accessors.
- Fix algorithm type of proof.
