### PR TITLE
Do not recreate the bouncycastle provider every time

### DIFF
--- a/src/main/java/org/eclipse/biscuit/crypto/SECP256R1KeyPair.java
+++ b/src/main/java/org/eclipse/biscuit/crypto/SECP256R1KeyPair.java
@@ -69,7 +69,8 @@ final class SECP256R1KeyPair extends KeyPair {
   }
 
   static Signature getSignature() throws NoSuchAlgorithmException {
-    return Signature.getInstance("SHA256withECDSA", new BouncyCastleProvider());
+    return Signature.getInstance(
+        "SHA256withECDSA", Security.getProvider(BouncyCastleProvider.PROVIDER_NAME));
   }
 
   @Override

--- a/src/test/java/org/eclipse/biscuit/crypto/SignatureTest.java
+++ b/src/test/java/org/eclipse/biscuit/crypto/SignatureTest.java
@@ -14,22 +14,15 @@ import biscuit.format.schema.Schema;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.security.Security;
 import java.security.SignatureException;
 import org.eclipse.biscuit.error.Error;
 import org.eclipse.biscuit.token.Biscuit;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.Test;
 
 /**
  * @serial exclude
  */
 public class SignatureTest {
-
-  static {
-    Security.addProvider(new BouncyCastleProvider());
-  }
-
   @Test
   public void testSerialize() {
     prTestSerialize(Schema.PublicKey.Algorithm.Ed25519, 32);


### PR DESCRIPTION
This is a huge performance improvement because creating the bc provider is expensive.