### PR TITLE
Reduce/change 3rd party dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
         <vavr.version>0.10.3</vavr.version>
         <re2j.version>1.6</re2j.version>
-        <gson.version>2.8.9</gson.version>
+        <jackson.version>2.17.3</jackson.version>
         <bcprov.version>1.80</bcprov.version>
 
         <!-- test dependencies -->
@@ -296,9 +296,9 @@
             <version>${re2j.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>${gson.version}</version>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
         <protobuf.version>3.25.5</protobuf.version>
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
         <os-maven-plugin.version>1.7.1</os-maven-plugin.version>
-        <vavr.version>0.10.3</vavr.version>
         <re2j.version>1.6</re2j.version>
         <jackson.version>2.17.3</jackson.version>
         <bcprov.version>1.80</bcprov.version>
@@ -284,11 +283,6 @@
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>${protobuf.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.vavr</groupId>
-            <artifactId>vavr</artifactId>
-            <version>${vavr.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.re2j</groupId>

--- a/src/main/java/org/eclipse/biscuit/crypto/BlockSignatureBuffer.java
+++ b/src/main/java/org/eclipse/biscuit/crypto/BlockSignatureBuffer.java
@@ -5,17 +5,14 @@
 
 package org.eclipse.biscuit.crypto;
 
-import static io.vavr.API.Left;
-import static io.vavr.API.Right;
-
 import biscuit.format.schema.Schema;
-import io.vavr.control.Either;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.stream.Stream;
 import org.eclipse.biscuit.error.Error;
+import org.eclipse.biscuit.error.Result;
 import org.eclipse.biscuit.token.format.ExternalSignature;
 import org.eclipse.biscuit.token.format.SerializedBiscuit;
 import org.eclipse.biscuit.token.format.SignedBlock;
@@ -59,7 +56,7 @@ public final class BlockSignatureBuffer {
     return previousSigVersions.mapToInt(Integer::intValue).max().orElse(0);
   }
 
-  public static Either<Error.FormatError, byte[]> generateBlockSignaturePayload(
+  public static Result<byte[], Error.FormatError> generateBlockSignaturePayload(
       byte[] payload,
       PublicKey nextKey,
       Optional<ExternalSignature> externalSignature,
@@ -67,13 +64,13 @@ public final class BlockSignatureBuffer {
       int version) {
     switch (version) {
       case 0:
-        return Right(generateBlockSignaturePayloadV0(payload, nextKey, externalSignature));
+        return Result.ok(generateBlockSignaturePayloadV0(payload, nextKey, externalSignature));
       case 1:
-        return Right(
+        return Result.ok(
             generateBlockSignaturePayloadV1(
                 payload, nextKey, externalSignature, previousSignature, version));
       default:
-        return Left(
+        return Result.err(
             new Error.FormatError.DeserializationError("unsupported block version " + version));
     }
   }

--- a/src/main/java/org/eclipse/biscuit/crypto/KeyDelegate.java
+++ b/src/main/java/org/eclipse/biscuit/crypto/KeyDelegate.java
@@ -5,7 +5,7 @@
 
 package org.eclipse.biscuit.crypto;
 
-import io.vavr.control.Option;
+import java.util.Optional;
 
 /**
  * Used to find the key associated with a key id
@@ -14,5 +14,5 @@ import io.vavr.control.Option;
  * time. Tokens can carry a root key id, that can be used to indicate which key will verify it.
  */
 public interface KeyDelegate {
-  Option<PublicKey> getRootKey(Option<Integer> keyId);
+  Optional<PublicKey> getRootKey(Optional<Integer> keyId);
 }

--- a/src/main/java/org/eclipse/biscuit/datalog/Check.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/Check.java
@@ -6,15 +6,13 @@
 package org.eclipse.biscuit.datalog;
 
 import static biscuit.format.schema.Schema.CheckV2.Kind.All;
-import static io.vavr.API.Left;
-import static io.vavr.API.Right;
 
 import biscuit.format.schema.Schema;
-import io.vavr.control.Either;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import org.eclipse.biscuit.error.Error;
+import org.eclipse.biscuit.error.Result;
 
 public final class Check {
   public enum Kind {
@@ -59,7 +57,7 @@ public final class Check {
     return b.build();
   }
 
-  public static Either<Error.FormatError, Check> deserializeV2(Schema.CheckV2 check) {
+  public static Result<Check, Error.FormatError> deserializeV2(Schema.CheckV2 check) {
     ArrayList<Rule> queries = new ArrayList<>();
 
     Kind kind;
@@ -76,16 +74,15 @@ public final class Check {
     }
 
     for (Schema.RuleV2 query : check.getQueriesList()) {
-      Either<Error.FormatError, Rule> res = Rule.deserializeV2(query);
-      if (res.isLeft()) {
-        Error.FormatError e = res.getLeft();
-        return Left(e);
+      var res = Rule.deserializeV2(query);
+      if (res.isErr()) {
+        return Result.err(res.getErr());
       } else {
-        queries.add(res.get());
+        queries.add(res.getOk());
       }
     }
 
-    return Right(new Check(kind, queries));
+    return Result.ok(new Check(kind, queries));
   }
 
   @Override

--- a/src/main/java/org/eclipse/biscuit/datalog/Combinator.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/Combinator.java
@@ -5,7 +5,6 @@
 
 package org.eclipse.biscuit.datalog;
 
-import io.vavr.Tuple2;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -17,17 +16,17 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
-public final class Combinator implements Serializable, Iterator<Tuple2<Origin, Map<Long, Term>>> {
+public final class Combinator implements Serializable, Iterator<Pair<Origin, Map<Long, Term>>> {
   private MatchedVariables variables;
-  private final Supplier<Stream<Tuple2<Origin, Fact>>> allFacts;
+  private final Supplier<Stream<Pair<Origin, Fact>>> allFacts;
   private final List<Predicate> predicates;
-  private final Iterator<Tuple2<Origin, Fact>> currentFacts;
+  private final Iterator<Pair<Origin, Fact>> currentFacts;
   private Combinator currentIt;
   private final SymbolTable symbolTable;
 
   private Origin currentOrigin;
 
-  private Optional<Tuple2<Origin, Map<Long, Term>>> nextElement;
+  private Optional<Pair<Origin, Map<Long, Term>>> nextElement;
 
   @Override
   public boolean hasNext() {
@@ -39,20 +38,20 @@ public final class Combinator implements Serializable, Iterator<Tuple2<Origin, M
   }
 
   @Override
-  public Tuple2<Origin, Map<Long, Term>> next() {
+  public Pair<Origin, Map<Long, Term>> next() {
     if (this.nextElement == null || !this.nextElement.isPresent()) {
       this.nextElement = getNext();
     }
     if (this.nextElement == null || !this.nextElement.isPresent()) {
       throw new NoSuchElementException();
     } else {
-      Tuple2<Origin, Map<Long, Term>> t = this.nextElement.get();
+      Pair<Origin, Map<Long, Term>> t = this.nextElement.get();
       this.nextElement = Optional.empty();
       return t;
     }
   }
 
-  public Optional<Tuple2<Origin, Map<Long, Term>>> getNext() {
+  public Optional<Pair<Origin, Map<Long, Term>>> getNext() {
     if (this.predicates.isEmpty()) {
       final Optional<Map<Long, Term>> vOpt = this.variables.complete();
       if (vOpt.isEmpty()) {
@@ -67,7 +66,7 @@ public final class Combinator implements Serializable, Iterator<Tuple2<Origin, M
         set.add((long) 0);
 
         this.variables = new MatchedVariables(set);
-        return Optional.of(new Tuple2<>(new Origin(), variables));
+        return Optional.of(new Pair<>(new Origin(), variables));
       }
     }
 
@@ -78,7 +77,7 @@ public final class Combinator implements Serializable, Iterator<Tuple2<Origin, M
         while (true) {
           // we iterate over the facts that match the current predicate
           if (this.currentFacts.hasNext()) {
-            final Tuple2<Origin, Fact> t = this.currentFacts.next();
+            final Pair<Origin, Fact> t = this.currentFacts.next();
             Origin currentOrigin = t._1.clone();
             Fact fact = t._2;
 
@@ -115,7 +114,7 @@ public final class Combinator implements Serializable, Iterator<Tuple2<Origin, M
               if (vOpt.isEmpty()) {
                 continue;
               } else {
-                return Optional.of(new Tuple2<>(currentOrigin, vOpt.get()));
+                return Optional.of(new Pair<>(currentOrigin, vOpt.get()));
               }
             } else {
               this.currentOrigin = currentOrigin;
@@ -141,11 +140,11 @@ public final class Combinator implements Serializable, Iterator<Tuple2<Origin, M
         return Optional.empty();
       }
 
-      Optional<Tuple2<Origin, Map<Long, Term>>> opt = this.currentIt.getNext();
+      Optional<Pair<Origin, Map<Long, Term>>> opt = this.currentIt.getNext();
 
       if (opt.isPresent()) {
-        Tuple2<Origin, Map<Long, Term>> t = opt.get();
-        return Optional.of(new Tuple2<>(t._1.union(currentOrigin), t._2));
+        Pair<Origin, Map<Long, Term>> t = opt.get();
+        return Optional.of(new Pair<>(t._1.union(currentOrigin), t._2));
       } else {
         currentOrigin = null;
         currentIt = null;
@@ -156,7 +155,7 @@ public final class Combinator implements Serializable, Iterator<Tuple2<Origin, M
   public Combinator(
       final MatchedVariables variables,
       final List<Predicate> predicates,
-      Supplier<Stream<Tuple2<Origin, Fact>>> allFacts,
+      Supplier<Stream<Pair<Origin, Fact>>> allFacts,
       final SymbolTable symbolTable) {
     this.variables = variables;
     this.allFacts = allFacts;

--- a/src/main/java/org/eclipse/biscuit/datalog/Combinator.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/Combinator.java
@@ -6,13 +6,13 @@
 package org.eclipse.biscuit.datalog;
 
 import io.vavr.Tuple2;
-import io.vavr.control.Option;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -27,36 +27,36 @@ public final class Combinator implements Serializable, Iterator<Tuple2<Origin, M
 
   private Origin currentOrigin;
 
-  private Option<Tuple2<Origin, Map<Long, Term>>> nextElement;
+  private Optional<Tuple2<Origin, Map<Long, Term>>> nextElement;
 
   @Override
   public boolean hasNext() {
-    if (this.nextElement != null && this.nextElement.isDefined()) {
+    if (this.nextElement != null && this.nextElement.isPresent()) {
       return true;
     }
     this.nextElement = getNext();
-    return this.nextElement.isDefined();
+    return this.nextElement.isPresent();
   }
 
   @Override
   public Tuple2<Origin, Map<Long, Term>> next() {
-    if (this.nextElement == null || !this.nextElement.isDefined()) {
+    if (this.nextElement == null || !this.nextElement.isPresent()) {
       this.nextElement = getNext();
     }
-    if (this.nextElement == null || !this.nextElement.isDefined()) {
+    if (this.nextElement == null || !this.nextElement.isPresent()) {
       throw new NoSuchElementException();
     } else {
       Tuple2<Origin, Map<Long, Term>> t = this.nextElement.get();
-      this.nextElement = Option.none();
+      this.nextElement = Optional.empty();
       return t;
     }
   }
 
-  public Option<Tuple2<Origin, Map<Long, Term>>> getNext() {
+  public Optional<Tuple2<Origin, Map<Long, Term>>> getNext() {
     if (this.predicates.isEmpty()) {
-      final Option<Map<Long, Term>> vOpt = this.variables.complete();
+      final Optional<Map<Long, Term>> vOpt = this.variables.complete();
       if (vOpt.isEmpty()) {
-        return Option.none();
+        return Optional.empty();
       } else {
         Map<Long, Term> variables = vOpt.get();
         // if there were no predicates,
@@ -67,7 +67,7 @@ public final class Combinator implements Serializable, Iterator<Tuple2<Origin, M
         set.add((long) 0);
 
         this.variables = new MatchedVariables(set);
-        return Option.some(new Tuple2<>(new Origin(), variables));
+        return Optional.of(new Tuple2<>(new Origin(), variables));
       }
     }
 
@@ -111,11 +111,11 @@ public final class Combinator implements Serializable, Iterator<Tuple2<Origin, M
 
             // there are no more predicates to check
             if (this.predicates.size() == 1) {
-              final Option<Map<Long, Term>> vOpt = vars.complete();
+              final Optional<Map<Long, Term>> vOpt = vars.complete();
               if (vOpt.isEmpty()) {
                 continue;
               } else {
-                return Option.some(new Tuple2<>(currentOrigin, vOpt.get()));
+                return Optional.of(new Tuple2<>(currentOrigin, vOpt.get()));
               }
             } else {
               this.currentOrigin = currentOrigin;
@@ -132,20 +132,20 @@ public final class Combinator implements Serializable, Iterator<Tuple2<Origin, M
             break;
 
           } else {
-            return Option.none();
+            return Optional.empty();
           }
         }
       }
 
       if (this.currentIt == null) {
-        return Option.none();
+        return Optional.empty();
       }
 
-      Option<Tuple2<Origin, Map<Long, Term>>> opt = this.currentIt.getNext();
+      Optional<Tuple2<Origin, Map<Long, Term>>> opt = this.currentIt.getNext();
 
-      if (opt.isDefined()) {
+      if (opt.isPresent()) {
         Tuple2<Origin, Map<Long, Term>> t = opt.get();
-        return Option.some(new Tuple2<>(t._1.union(currentOrigin), t._2));
+        return Optional.of(new Tuple2<>(t._1.union(currentOrigin), t._2));
       } else {
         currentOrigin = null;
         currentIt = null;

--- a/src/main/java/org/eclipse/biscuit/datalog/Fact.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/Fact.java
@@ -5,15 +5,12 @@
 
 package org.eclipse.biscuit.datalog;
 
-import static io.vavr.API.Left;
-import static io.vavr.API.Right;
-
 import biscuit.format.schema.Schema;
-import io.vavr.control.Either;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Objects;
 import org.eclipse.biscuit.error.Error;
+import org.eclipse.biscuit.error.Result;
 
 public final class Fact implements Serializable {
   private final Predicate predicate;
@@ -60,13 +57,12 @@ public final class Fact implements Serializable {
     return Schema.FactV2.newBuilder().setPredicate(this.predicate.serialize()).build();
   }
 
-  public static Either<Error.FormatError, Fact> deserializeV2(Schema.FactV2 fact) {
-    Either<Error.FormatError, Predicate> res = Predicate.deserializeV2(fact.getPredicate());
-    if (res.isLeft()) {
-      Error.FormatError e = res.getLeft();
-      return Left(e);
+  public static Result<Fact, Error.FormatError> deserializeV2(Schema.FactV2 fact) {
+    var res = Predicate.deserializeV2(fact.getPredicate());
+    if (res.isErr()) {
+      return Result.err(res.getErr());
     } else {
-      return Right(new Fact(res.get()));
+      return Result.ok(new Fact(res.getOk()));
     }
   }
 }

--- a/src/main/java/org/eclipse/biscuit/datalog/FactSet.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/FactSet.java
@@ -5,7 +5,6 @@
 
 package org.eclipse.biscuit.datalog;
 
-import io.vavr.Tuple2;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -71,8 +70,7 @@ public final class FactSet {
               Origin o = entry.getKey();
               return blockIds.contains(o);
             })
-        .flatMap(
-            entry -> entry.getValue().stream().map(fact -> new Tuple2<>(entry.getKey(), fact)));
+        .flatMap(entry -> entry.getValue().stream().map(fact -> new Pair<>(entry.getKey(), fact)));
   }
 
   public Stream<Fact> stream() {

--- a/src/main/java/org/eclipse/biscuit/datalog/MatchedVariables.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/MatchedVariables.java
@@ -5,7 +5,6 @@
 
 package org.eclipse.biscuit.datalog;
 
-import io.vavr.control.Option;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.List;
@@ -40,16 +39,16 @@ public final class MatchedVariables implements Serializable {
     return this.variables.values().stream().allMatch((v) -> v.isPresent());
   }
 
-  public Option<Map<Long, Term>> complete() {
+  public Optional<Map<Long, Term>> complete() {
     final Map<Long, Term> variables = new HashMap<>();
     for (final Map.Entry<Long, Optional<Term>> entry : this.variables.entrySet()) {
       if (entry.getValue().isPresent()) {
         variables.put(entry.getKey(), entry.getValue().get());
       } else {
-        return Option.none();
+        return Optional.empty();
       }
     }
-    return Option.some(variables);
+    return Optional.of(variables);
   }
 
   public MatchedVariables clone() {
@@ -69,10 +68,10 @@ public final class MatchedVariables implements Serializable {
     }
   }
 
-  public Option<Map<Long, Term>> checkExpressions(
+  public Optional<Map<Long, Term>> checkExpressions(
       List<Expression> expressions, SymbolTable symbolTable) throws Error {
-    final Option<Map<Long, Term>> vars = this.complete();
-    if (vars.isDefined()) {
+    final Optional<Map<Long, Term>> vars = this.complete();
+    if (vars.isPresent()) {
       Map<Long, Term> variables = vars.get();
 
       for (Expression e : expressions) {
@@ -82,13 +81,13 @@ public final class MatchedVariables implements Serializable {
           throw new Error.InvalidType();
         }
         if (!term.equals(new Term.Bool(true))) {
-          return Option.none();
+          return Optional.empty();
         }
       }
 
-      return Option.some(variables);
+      return Optional.of(variables);
     } else {
-      return Option.none();
+      return Optional.empty();
     }
   }
 }

--- a/src/main/java/org/eclipse/biscuit/datalog/Pair.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/Pair.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019 Geoffroy Couprie <contact@geoffroycouprie.com> and Contributors to the Eclipse Foundation.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.biscuit.datalog;
+
+import java.util.Objects;
+
+public final class Pair<T1, T2> {
+  public final T1 _1;
+  public final T2 _2;
+
+  public Pair(T1 t1, T2 t2) {
+    this._1 = t1;
+    this._2 = t2;
+  }
+
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof Pair)) {
+      return false;
+    }
+    Pair<?, ?> that = (Pair<?, ?>) o;
+    return Objects.equals(this._1, that._1) && Objects.equals(this._2, that._2);
+  }
+
+  public int hashCode() {
+    int result = 1;
+    result = 31 * result + _1.hashCode();
+    result = 31 * result + _2.hashCode();
+    return result;
+  }
+
+  public String toString() {
+    return "(" + this._1 + ", " + this._2 + ")";
+  }
+}

--- a/src/main/java/org/eclipse/biscuit/datalog/Predicate.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/Predicate.java
@@ -5,11 +5,7 @@
 
 package org.eclipse.biscuit.datalog;
 
-import static io.vavr.API.Left;
-import static io.vavr.API.Right;
-
 import biscuit.format.schema.Schema;
-import io.vavr.control.Either;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +13,7 @@ import java.util.ListIterator;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.eclipse.biscuit.error.Error;
+import org.eclipse.biscuit.error.Result;
 
 public final class Predicate implements Serializable {
   private final long name;
@@ -99,18 +96,17 @@ public final class Predicate implements Serializable {
     return builder.build();
   }
 
-  public static Either<Error.FormatError, Predicate> deserializeV2(Schema.PredicateV2 predicate) {
+  public static Result<Predicate, Error.FormatError> deserializeV2(Schema.PredicateV2 predicate) {
     ArrayList<Term> terms = new ArrayList<>();
     for (Schema.TermV2 id : predicate.getTermsList()) {
-      Either<Error.FormatError, Term> res = Term.deserializeEnumV2(id);
-      if (res.isLeft()) {
-        Error.FormatError e = res.getLeft();
-        return Left(e);
+      var res = Term.deserializeEnumV2(id);
+      if (res.isErr()) {
+        return Result.err(res.getErr());
       } else {
-        terms.add(res.get());
+        terms.add(res.getOk());
       }
     }
 
-    return Right(new Predicate(predicate.getName(), terms));
+    return Result.ok(new Predicate(predicate.getName(), terms));
   }
 }

--- a/src/main/java/org/eclipse/biscuit/datalog/Rule.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/Rule.java
@@ -137,7 +137,7 @@ public final class Rule implements Serializable {
     MatchedVariables variables = variablesSet();
 
     if (this.body.isEmpty()) {
-      return variables.checkExpressions(this.expressions, symbolTable).isDefined();
+      return variables.checkExpressions(this.expressions, symbolTable).isPresent();
     }
 
     Supplier<Stream<Tuple2<Origin, Fact>>> factsSupplier = () -> facts.stream(scope);
@@ -164,7 +164,7 @@ public final class Rule implements Serializable {
     MatchedVariables variables = variablesSet();
 
     if (this.body.isEmpty()) {
-      return variables.checkExpressions(this.expressions, symbolTable).isDefined();
+      return variables.checkExpressions(this.expressions, symbolTable).isPresent();
     }
 
     Supplier<Stream<Tuple2<Origin, Fact>>> factsSupplier = () -> facts.stream(scope);

--- a/src/main/java/org/eclipse/biscuit/datalog/Rule.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/Rule.java
@@ -58,9 +58,6 @@ public final class Rule implements Serializable {
         Spliterators.spliteratorUnknownSize(combinator, Spliterator.ORDERED);
     Stream<Tuple2<Origin, Map<Long, Term>>> stream = StreamSupport.stream(splitItr, false);
 
-    // (Tuple3<Origin, Map<Long, Term>, Boolean>)
-
-    // somehow we have inference errors when writing this as a lambda
     return stream
         .map(
             t -> {
@@ -89,7 +86,6 @@ public final class Rule implements Serializable {
               return Result.<Tuple3<Origin, Map<Long, Term>, Boolean>, Error>ok(
                   new Tuple3<>(origin, generatedVariables, true));
             })
-        // sometimes we need to make the compiler happy
         .filter(res -> res.isOk() & res.getOk()._3)
         .map(
             res -> {

--- a/src/main/java/org/eclipse/biscuit/datalog/Rule.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/Rule.java
@@ -5,17 +5,12 @@
 
 package org.eclipse.biscuit.datalog;
 
-import static io.vavr.API.Left;
-import static io.vavr.API.Right;
-
 import biscuit.format.schema.Schema;
 import io.vavr.Tuple2;
 import io.vavr.Tuple3;
-import io.vavr.control.Either;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -28,6 +23,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.eclipse.biscuit.datalog.expressions.Expression;
 import org.eclipse.biscuit.error.Error;
+import org.eclipse.biscuit.error.Result;
 
 public final class Rule implements Serializable {
   private final Predicate head;
@@ -51,7 +47,7 @@ public final class Rule implements Serializable {
     return scopes;
   }
 
-  public Stream<Either<Error, Tuple2<Origin, Fact>>> apply(
+  public Stream<Result<Tuple2<Origin, Fact>, Error>> apply(
       final Supplier<Stream<Tuple2<Origin, Fact>>> factsSupplier,
       Long ruleOrigin,
       SymbolTable symbolTable) {
@@ -61,6 +57,8 @@ public final class Rule implements Serializable {
     Spliterator<Tuple2<Origin, Map<Long, Term>>> splitItr =
         Spliterators.spliteratorUnknownSize(combinator, Spliterator.ORDERED);
     Stream<Tuple2<Origin, Map<Long, Term>>> stream = StreamSupport.stream(splitItr, false);
+
+    // (Tuple3<Origin, Map<Long, Term>, Boolean>)
 
     // somehow we have inference errors when writing this as a lambda
     return stream
@@ -76,26 +74,26 @@ public final class Rule implements Serializable {
                   if (term instanceof Term.Bool) {
                     Term.Bool b = (Term.Bool) term;
                     if (!b.value()) {
-                      return Either.right(new Tuple3<>(origin, generatedVariables, false));
+                      return Result.<Tuple3<Origin, Map<Long, Term>, Boolean>, Error>ok(
+                          new Tuple3<>(origin, generatedVariables, false));
                     }
                     // continue evaluating if true
                   } else {
-                    return Either.left(new Error.InvalidType());
+                    return Result.<Tuple3<Origin, Map<Long, Term>, Boolean>, Error>err(
+                        new Error.InvalidType());
                   }
                 } catch (Error error) {
-                  return Either.left(error);
+                  return Result.<Tuple3<Origin, Map<Long, Term>, Boolean>, Error>err(error);
                 }
               }
-              return Either.right(new Tuple3<>(origin, generatedVariables, true));
+              return Result.<Tuple3<Origin, Map<Long, Term>, Boolean>, Error>ok(
+                  new Tuple3<>(origin, generatedVariables, true));
             })
         // sometimes we need to make the compiler happy
-        .filter(
-            (java.util.function.Predicate<? super Either<? extends Object, ? extends Object>>)
-                res -> res.isRight() & ((Tuple3<Origin, Map<Long, Term>, Boolean>) res.get())._3)
+        .filter(res -> res.isOk() & res.getOk()._3)
         .map(
             res -> {
-              Tuple3<Origin, Map<Long, Term>, Boolean> t =
-                  (Tuple3<Origin, Map<Long, Term>, Boolean>) res.get();
+              var t = res.getOk();
               Origin origin = t._1;
               Map<Long, Term> generatedVariables = t._2;
 
@@ -106,14 +104,14 @@ public final class Rule implements Serializable {
                   if (!generatedVariables.containsKey(var.value())) {
                     // throw new Error("variables that appear in the head should appear in the body
                     // as well");
-                    return Either.left(new Error.InternalError());
+                    return Result.err(new Error.InternalError());
                   }
                   p.terms().set(index, generatedVariables.get(var.value()));
                 }
               }
 
               origin.add(ruleOrigin);
-              return Either.right(new Tuple2<Origin, Fact>(origin, new Fact(p)));
+              return Result.ok(new Tuple2<Origin, Fact>(origin, new Fact(p)));
             });
   }
 
@@ -141,20 +139,18 @@ public final class Rule implements Serializable {
     }
 
     Supplier<Stream<Tuple2<Origin, Fact>>> factsSupplier = () -> facts.stream(scope);
-    Stream<Either<Error, Tuple2<Origin, Fact>>> stream =
-        this.apply(factsSupplier, origin, symbolTable);
-
-    Iterator<Either<Error, Tuple2<Origin, Fact>>> it = stream.iterator();
+    var stream = this.apply(factsSupplier, origin, symbolTable);
+    var it = stream.iterator();
 
     if (!it.hasNext()) {
       return false;
     }
 
-    Either<Error, Tuple2<Origin, Fact>> next = it.next();
-    if (next.isRight()) {
+    var next = it.next();
+    if (next.isOk()) {
       return true;
     } else {
-      throw next.getLeft();
+      throw next.getErr();
     }
   }
 
@@ -231,46 +227,43 @@ public final class Rule implements Serializable {
     return b.build();
   }
 
-  public static Either<Error.FormatError, Rule> deserializeV2(Schema.RuleV2 rule) {
+  public static Result<Rule, Error.FormatError> deserializeV2(Schema.RuleV2 rule) {
     ArrayList<Predicate> body = new ArrayList<>();
     for (Schema.PredicateV2 predicate : rule.getBodyList()) {
-      Either<Error.FormatError, Predicate> res = Predicate.deserializeV2(predicate);
-      if (res.isLeft()) {
-        Error.FormatError e = res.getLeft();
-        return Left(e);
+      var res = Predicate.deserializeV2(predicate);
+      if (res.isErr()) {
+        return Result.err(res.getErr());
       } else {
-        body.add(res.get());
+        body.add(res.getOk());
       }
     }
 
     ArrayList<Expression> expressions = new ArrayList<>();
     for (Schema.ExpressionV2 expression : rule.getExpressionsList()) {
-      Either<Error.FormatError, Expression> res = Expression.deserializeV2(expression);
-      if (res.isLeft()) {
-        Error.FormatError e = res.getLeft();
-        return Left(e);
+      var res = Expression.deserializeV2(expression);
+      if (res.isErr()) {
+        return Result.err(res.getErr());
       } else {
-        expressions.add(res.get());
+        expressions.add(res.getOk());
       }
     }
 
     ArrayList<Scope> scopes = new ArrayList<>();
     for (Schema.Scope scope : rule.getScopeList()) {
-      Either<Error.FormatError, Scope> res = Scope.deserialize(scope);
-      if (res.isLeft()) {
-        Error.FormatError e = res.getLeft();
-        return Left(e);
+      var res = Scope.deserialize(scope);
+      if (res.isErr()) {
+        return Result.err(res.getErr());
       } else {
-        scopes.add(res.get());
+        scopes.add(res.getOk());
       }
     }
 
-    Either<Error.FormatError, Predicate> res = Predicate.deserializeV2(rule.getHead());
-    if (res.isLeft()) {
-      Error.FormatError e = res.getLeft();
-      return Left(e);
+    var res = Predicate.deserializeV2(rule.getHead());
+    if (res.isErr()) {
+      Error.FormatError e = res.getErr();
+      return Result.err(e);
     } else {
-      return Right(new Rule(res.get(), body, expressions, scopes));
+      return Result.ok(new Rule(res.getOk(), body, expressions, scopes));
     }
   }
 

--- a/src/main/java/org/eclipse/biscuit/datalog/RuleSet.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/RuleSet.java
@@ -5,7 +5,6 @@
 
 package org.eclipse.biscuit.datalog;
 
-import io.vavr.Tuple2;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -13,7 +12,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 public final class RuleSet {
-  private final HashMap<TrustedOrigins, List<Tuple2<Long, Rule>>> rules;
+  private final HashMap<TrustedOrigins, List<Pair<Long, Rule>>> rules;
 
   public RuleSet() {
     rules = new HashMap<>();
@@ -21,17 +20,17 @@ public final class RuleSet {
 
   public void add(Long origin, TrustedOrigins scope, Rule rule) {
     if (!rules.containsKey(scope)) {
-      rules.put(scope, List.of(new Tuple2<>(origin, rule)));
+      rules.put(scope, List.of(new Pair<>(origin, rule)));
     } else {
-      rules.get(scope).add(new Tuple2<>(origin, rule));
+      rules.get(scope).add(new Pair<>(origin, rule));
     }
   }
 
   public RuleSet clone() {
     RuleSet newRules = new RuleSet();
 
-    for (Map.Entry<TrustedOrigins, List<Tuple2<Long, Rule>>> entry : this.rules.entrySet()) {
-      List<Tuple2<Long, Rule>> l = new ArrayList<>(entry.getValue());
+    for (Map.Entry<TrustedOrigins, List<Pair<Long, Rule>>> entry : this.rules.entrySet()) {
+      List<Pair<Long, Rule>> l = new ArrayList<>(entry.getValue());
       newRules.rules.put(entry.getKey(), l);
     }
 
@@ -46,7 +45,7 @@ public final class RuleSet {
     this.rules.clear();
   }
 
-  public HashMap<TrustedOrigins, List<Tuple2<Long, Rule>>> getRules() {
+  public HashMap<TrustedOrigins, List<Pair<Long, Rule>>> getRules() {
     return this.rules;
   }
 }

--- a/src/main/java/org/eclipse/biscuit/datalog/SchemaVersion.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/SchemaVersion.java
@@ -5,14 +5,11 @@
 
 package org.eclipse.biscuit.datalog;
 
-import static io.vavr.API.Left;
-import static io.vavr.API.Right;
-
-import io.vavr.control.Either;
 import java.util.List;
 import org.eclipse.biscuit.datalog.expressions.Expression;
 import org.eclipse.biscuit.datalog.expressions.Op;
 import org.eclipse.biscuit.error.Error;
+import org.eclipse.biscuit.error.Result;
 import org.eclipse.biscuit.token.format.SerializedBiscuit;
 
 public final class SchemaVersion {
@@ -69,22 +66,24 @@ public final class SchemaVersion {
     }
   }
 
-  public Either<Error.FormatError, Void> checkCompatibility(int version) {
+  public Result<Void, Error.FormatError> checkCompatibility(int version) {
     if (version < 4) {
       if (containsScopes) {
-        return Left(new Error.FormatError.DeserializationError("v3 blocks must not have scopes"));
+        return Result.err(
+            new Error.FormatError.DeserializationError("v3 blocks must not have scopes"));
       }
       if (containsV4) {
-        return Left(
+        return Result.err(
             new Error.FormatError.DeserializationError(
                 "v3 blocks must not have v4 operators (bitwise operators or !="));
       }
       if (containsCheckAll) {
-        return Left(new Error.FormatError.DeserializationError("v3 blocks must not use check all"));
+        return Result.err(
+            new Error.FormatError.DeserializationError("v3 blocks must not use check all"));
       }
     }
 
-    return Right(null);
+    return Result.ok(null);
   }
 
   public static boolean containsV4Ops(List<Expression> expressions) {

--- a/src/main/java/org/eclipse/biscuit/datalog/Scope.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/Scope.java
@@ -5,12 +5,9 @@
 
 package org.eclipse.biscuit.datalog;
 
-import static io.vavr.API.Left;
-import static io.vavr.API.Right;
-
 import biscuit.format.schema.Schema;
-import io.vavr.control.Either;
 import org.eclipse.biscuit.error.Error;
+import org.eclipse.biscuit.error.Result;
 
 public final class Scope {
   public enum Kind {
@@ -66,22 +63,22 @@ public final class Scope {
     return b.build();
   }
 
-  public static Either<Error.FormatError, Scope> deserialize(Schema.Scope scope) {
+  public static Result<Scope, Error.FormatError> deserialize(Schema.Scope scope) {
     if (scope.hasPublicKey()) {
       long publicKey = scope.getPublicKey();
-      return Right(Scope.publicKey(publicKey));
+      return Result.ok(Scope.publicKey(publicKey));
     }
     if (scope.hasScopeType()) {
       switch (scope.getScopeType()) {
         case Authority:
-          return Right(Scope.authority());
+          return Result.ok(Scope.authority());
         case Previous:
-          return Right(Scope.previous());
+          return Result.ok(Scope.previous());
         default:
-          return Left(new Error.FormatError.DeserializationError("invalid Scope"));
+          return Result.err(new Error.FormatError.DeserializationError("invalid Scope"));
       }
     }
-    return Left(new Error.FormatError.DeserializationError("invalid Scope"));
+    return Result.err(new Error.FormatError.DeserializationError("invalid Scope"));
   }
 
   @Override

--- a/src/main/java/org/eclipse/biscuit/datalog/SymbolTable.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/SymbolTable.java
@@ -5,7 +5,6 @@
 
 package org.eclipse.biscuit.datalog;
 
-import io.vavr.control.Option;
 import java.io.Serializable;
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -112,37 +111,37 @@ public final class SymbolTable implements Serializable {
     return new Term.Str(this.insert(symbol));
   }
 
-  public Option<Long> get(final String symbol) {
+  public Optional<Long> get(final String symbol) {
     // looking for symbol in default symbols
     long index = this.DEFAULT_SYMBOLS.indexOf(symbol);
     if (index == -1) {
       // looking for symbol in usages defined symbols
       index = this.symbols.indexOf(symbol);
       if (index == -1) {
-        return Option.none();
+        return Optional.empty();
       } else {
-        return Option.some(index + DEFAULT_SYMBOLS_OFFSET);
+        return Optional.of(index + DEFAULT_SYMBOLS_OFFSET);
       }
     } else {
-      return Option.some(index);
+      return Optional.of(index);
     }
   }
 
-  public Option<String> getSymbol(int i) {
+  public Optional<String> getSymbol(int i) {
     if (i >= 0 && i < this.DEFAULT_SYMBOLS.size() && i < DEFAULT_SYMBOLS_OFFSET) {
-      return Option.some(this.DEFAULT_SYMBOLS.get(i));
+      return Optional.of(this.DEFAULT_SYMBOLS.get(i));
     } else if (i >= DEFAULT_SYMBOLS_OFFSET && i < this.symbols.size() + DEFAULT_SYMBOLS_OFFSET) {
-      return Option.some(this.symbols.get(i - DEFAULT_SYMBOLS_OFFSET));
+      return Optional.of(this.symbols.get(i - DEFAULT_SYMBOLS_OFFSET));
     } else {
-      return Option.none();
+      return Optional.empty();
     }
   }
 
-  public Option<PublicKey> getPublicKey(int i) {
+  public Optional<PublicKey> getPublicKey(int i) {
     if (i >= 0 && i < this.publicKeys.size()) {
-      return Option.some(this.publicKeys.get(i));
+      return Optional.of(this.publicKeys.get(i));
     } else {
-      return Option.none();
+      return Optional.empty();
     }
   }
 
@@ -187,8 +186,8 @@ public final class SymbolTable implements Serializable {
       case Previous:
         return "previous";
       case PublicKey:
-        Option<PublicKey> pk = this.getPublicKey((int) scope.getPublicKey());
-        if (pk.isDefined()) {
+        Optional<PublicKey> pk = this.getPublicKey((int) scope.getPublicKey());
+        if (pk.isPresent()) {
           return pk.get().toString();
         } else {
           return "<" + scope.getPublicKey() + "?>";
@@ -274,7 +273,7 @@ public final class SymbolTable implements Serializable {
   }
 
   public String formatSymbol(int i) {
-    return getSymbol(i).getOrElse("<" + i + "?>");
+    return getSymbol(i).orElse("<" + i + "?>");
   }
 
   public SymbolTable() {

--- a/src/main/java/org/eclipse/biscuit/datalog/TemporarySymbolTable.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/TemporarySymbolTable.java
@@ -7,9 +7,9 @@ package org.eclipse.biscuit.datalog;
 
 import static org.eclipse.biscuit.datalog.SymbolTable.DEFAULT_SYMBOLS_OFFSET;
 
-import io.vavr.control.Option;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public final class TemporarySymbolTable {
   private SymbolTable base;
@@ -22,12 +22,12 @@ public final class TemporarySymbolTable {
     this.symbols = new ArrayList<>();
   }
 
-  public Option<String> getSymbol(int i) {
+  public Optional<String> getSymbol(int i) {
     if (i >= this.offset) {
       if (i - this.offset < this.symbols.size()) {
-        return Option.some(this.symbols.get(i - this.offset));
+        return Optional.of(this.symbols.get(i - this.offset));
       } else {
-        return Option.none();
+        return Optional.empty();
       }
     } else {
       return this.base.getSymbol(i);
@@ -35,8 +35,8 @@ public final class TemporarySymbolTable {
   }
 
   public long insert(final String symbol) {
-    Option<Long> opt = this.base.get(symbol);
-    if (opt.isDefined()) {
+    Optional<Long> opt = this.base.get(symbol);
+    if (opt.isPresent()) {
       return opt.get();
     }
 

--- a/src/main/java/org/eclipse/biscuit/datalog/World.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/World.java
@@ -5,7 +5,6 @@
 
 package org.eclipse.biscuit.datalog;
 
-import io.vavr.Tuple2;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.HashSet;
@@ -43,10 +42,10 @@ public final class World implements Serializable {
     while (true) {
       final FactSet newFacts = new FactSet();
 
-      for (Map.Entry<TrustedOrigins, List<Tuple2<Long, Rule>>> entry :
+      for (Map.Entry<TrustedOrigins, List<Pair<Long, Rule>>> entry :
           this.rules.getRules().entrySet()) {
-        for (Tuple2<Long, Rule> t : entry.getValue()) {
-          Supplier<Stream<Tuple2<Origin, Fact>>> factsSupplier =
+        for (Pair<Long, Rule> t : entry.getValue()) {
+          Supplier<Stream<Pair<Origin, Fact>>> factsSupplier =
               () -> this.facts.stream(entry.getKey());
 
           var stream = t._2.apply(factsSupplier, t._1, symbolTable);
@@ -57,7 +56,7 @@ public final class World implements Serializable {
             }
 
             if (res.isOk()) {
-              Tuple2<Origin, Fact> t2 = res.getOk();
+              Pair<Origin, Fact> t2 = res.getOk();
               newFacts.add(t2._1, t2._2);
             } else {
               throw res.getErr();
@@ -96,14 +95,14 @@ public final class World implements Serializable {
       final Rule rule, Long origin, TrustedOrigins scope, SymbolTable symbolTable) throws Error {
     final FactSet newFacts = new FactSet();
 
-    Supplier<Stream<Tuple2<Origin, Fact>>> factsSupplier = () -> this.facts.stream(scope);
+    Supplier<Stream<Pair<Origin, Fact>>> factsSupplier = () -> this.facts.stream(scope);
 
     var stream = rule.apply(factsSupplier, origin, symbolTable);
     for (var it = stream.iterator(); it.hasNext(); ) {
       var res = it.next();
 
       if (res.isOk()) {
-        Tuple2<Origin, Fact> t2 = res.getOk();
+        Pair<Origin, Fact> t2 = res.getOk();
         newFacts.add(t2._1, t2._2);
       } else {
         throw res.getErr();

--- a/src/main/java/org/eclipse/biscuit/datalog/World.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/World.java
@@ -6,7 +6,6 @@
 package org.eclipse.biscuit.datalog;
 
 import io.vavr.Tuple2;
-import io.vavr.control.Either;
 import java.io.Serializable;
 import java.time.Instant;
 import java.util.HashSet;
@@ -50,20 +49,18 @@ public final class World implements Serializable {
           Supplier<Stream<Tuple2<Origin, Fact>>> factsSupplier =
               () -> this.facts.stream(entry.getKey());
 
-          Stream<Either<Error, Tuple2<Origin, Fact>>> stream =
-              t._2.apply(factsSupplier, t._1, symbolTable);
-          for (Iterator<Either<Error, Tuple2<Origin, Fact>>> it = stream.iterator();
-              it.hasNext(); ) {
-            Either<Error, Tuple2<Origin, Fact>> res = it.next();
+          var stream = t._2.apply(factsSupplier, t._1, symbolTable);
+          for (var it = stream.iterator(); it.hasNext(); ) {
+            var res = it.next();
             if (Instant.now().compareTo(limit) >= 0) {
               throw new Error.Timeout();
             }
 
-            if (res.isRight()) {
-              Tuple2<Origin, Fact> t2 = res.get();
+            if (res.isOk()) {
+              Tuple2<Origin, Fact> t2 = res.getOk();
               newFacts.add(t2._1, t2._2);
             } else {
-              throw res.getLeft();
+              throw res.getErr();
             }
           }
         }
@@ -101,16 +98,15 @@ public final class World implements Serializable {
 
     Supplier<Stream<Tuple2<Origin, Fact>>> factsSupplier = () -> this.facts.stream(scope);
 
-    Stream<Either<Error, Tuple2<Origin, Fact>>> stream =
-        rule.apply(factsSupplier, origin, symbolTable);
-    for (Iterator<Either<Error, Tuple2<Origin, Fact>>> it = stream.iterator(); it.hasNext(); ) {
-      Either<Error, Tuple2<Origin, Fact>> res = it.next();
+    var stream = rule.apply(factsSupplier, origin, symbolTable);
+    for (var it = stream.iterator(); it.hasNext(); ) {
+      var res = it.next();
 
-      if (res.isRight()) {
-        Tuple2<Origin, Fact> t2 = res.get();
+      if (res.isOk()) {
+        Tuple2<Origin, Fact> t2 = res.getOk();
         newFacts.add(t2._1, t2._2);
       } else {
-        throw res.getLeft();
+        throw res.getErr();
       }
     }
 

--- a/src/main/java/org/eclipse/biscuit/datalog/expressions/Expression.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/expressions/Expression.java
@@ -5,11 +5,7 @@
 
 package org.eclipse.biscuit.datalog.expressions;
 
-import static io.vavr.API.Left;
-import static io.vavr.API.Right;
-
 import biscuit.format.schema.Schema;
-import io.vavr.control.Either;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -20,6 +16,7 @@ import org.eclipse.biscuit.datalog.SymbolTable;
 import org.eclipse.biscuit.datalog.TemporarySymbolTable;
 import org.eclipse.biscuit.datalog.Term;
 import org.eclipse.biscuit.error.Error;
+import org.eclipse.biscuit.error.Result;
 
 public final class Expression {
   private final ArrayList<Op> ops;
@@ -68,21 +65,20 @@ public final class Expression {
     return b.build();
   }
 
-  public static Either<Error.FormatError, Expression> deserializeV2(Schema.ExpressionV2 e) {
+  public static Result<Expression, Error.FormatError> deserializeV2(Schema.ExpressionV2 e) {
     ArrayList<Op> ops = new ArrayList<>();
 
     for (Schema.Op op : e.getOpsList()) {
-      Either<Error.FormatError, Op> res = Op.deserializeV2(op);
+      var res = Op.deserializeV2(op);
 
-      if (res.isLeft()) {
-        Error.FormatError err = res.getLeft();
-        return Left(err);
+      if (res.isErr()) {
+        return Result.err(res.getErr());
       } else {
-        ops.add(res.get());
+        ops.add(res.getOk());
       }
     }
 
-    return Right(new Expression(ops));
+    return Result.ok(new Expression(ops));
   }
 
   @Override

--- a/src/main/java/org/eclipse/biscuit/datalog/expressions/Expression.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/expressions/Expression.java
@@ -10,12 +10,12 @@ import static io.vavr.API.Right;
 
 import biscuit.format.schema.Schema;
 import io.vavr.control.Either;
-import io.vavr.control.Option;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import org.eclipse.biscuit.datalog.SymbolTable;
 import org.eclipse.biscuit.datalog.TemporarySymbolTable;
 import org.eclipse.biscuit.datalog.Term;
@@ -46,15 +46,15 @@ public final class Expression {
     }
   }
 
-  public Option<String> print(SymbolTable symbolTable) {
+  public Optional<String> print(SymbolTable symbolTable) {
     Deque<String> stack = new ArrayDeque<>();
     for (Op op : ops) {
       op.print(stack, symbolTable);
     }
     if (stack.size() == 1) {
-      return Option.some(stack.remove());
+      return Optional.of(stack.remove());
     } else {
-      return Option.none();
+      return Optional.empty();
     }
   }
 

--- a/src/main/java/org/eclipse/biscuit/datalog/expressions/Op.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/expressions/Op.java
@@ -5,13 +5,9 @@
 
 package org.eclipse.biscuit.datalog.expressions;
 
-import static io.vavr.API.Left;
-import static io.vavr.API.Right;
-
 import biscuit.format.schema.Schema;
 import com.google.re2j.Matcher;
 import com.google.re2j.Pattern;
-import io.vavr.control.Either;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Deque;
@@ -23,6 +19,7 @@ import org.eclipse.biscuit.datalog.SymbolTable;
 import org.eclipse.biscuit.datalog.TemporarySymbolTable;
 import org.eclipse.biscuit.datalog.Term;
 import org.eclipse.biscuit.error.Error;
+import org.eclipse.biscuit.error.Result;
 
 public abstract class Op {
   public abstract void evaluate(
@@ -33,15 +30,16 @@ public abstract class Op {
 
   public abstract Schema.Op serialize();
 
-  public static Either<Error.FormatError, Op> deserializeV2(Schema.Op op) {
+  public static Result<Op, Error.FormatError> deserializeV2(Schema.Op op) {
     if (op.hasValue()) {
-      return Term.deserializeEnumV2(op.getValue()).map(v -> new Op.Value(v));
+      var res = Term.deserializeEnumV2(op.getValue());
+      return res.isOk() ? Result.ok(new Op.Value(res.getOk())) : Result.err(res.getErr());
     } else if (op.hasUnary()) {
       return Op.Unary.deserializeV2(op.getUnary());
     } else if (op.hasBinary()) {
       return Op.Binary.deserializeV1(op.getBinary());
     } else {
-      return Left(new Error.FormatError.DeserializationError("invalid unary operation"));
+      return Result.err(new Error.FormatError.DeserializationError("invalid unary operation"));
     }
   }
 
@@ -219,18 +217,18 @@ public abstract class Op {
       return b.build();
     }
 
-    public static Either<Error.FormatError, Op> deserializeV2(Schema.OpUnary op) {
+    public static Result<Op, Error.FormatError> deserializeV2(Schema.OpUnary op) {
       switch (op.getKind()) {
         case Negate:
-          return Right(new Op.Unary(UnaryOp.Negate));
+          return Result.ok(new Op.Unary(UnaryOp.Negate));
         case Parens:
-          return Right(new Op.Unary(UnaryOp.Parens));
+          return Result.ok(new Op.Unary(UnaryOp.Parens));
         case Length:
-          return Right(new Op.Unary(UnaryOp.Length));
+          return Result.ok(new Op.Unary(UnaryOp.Length));
         default:
       }
 
-      return Left(new Error.FormatError.DeserializationError("invalid unary operation"));
+      return Result.err(new Error.FormatError.DeserializationError("invalid unary operation"));
     }
 
     @Override
@@ -773,52 +771,52 @@ public abstract class Op {
       return b.build();
     }
 
-    public static Either<Error.FormatError, Op> deserializeV1(Schema.OpBinary op) {
+    public static Result<Op, Error.FormatError> deserializeV1(Schema.OpBinary op) {
       switch (op.getKind()) {
         case LessThan:
-          return Right(new Op.Binary(BinaryOp.LessThan));
+          return Result.ok(new Op.Binary(BinaryOp.LessThan));
         case GreaterThan:
-          return Right(new Op.Binary(BinaryOp.GreaterThan));
+          return Result.ok(new Op.Binary(BinaryOp.GreaterThan));
         case LessOrEqual:
-          return Right(new Op.Binary(BinaryOp.LessOrEqual));
+          return Result.ok(new Op.Binary(BinaryOp.LessOrEqual));
         case GreaterOrEqual:
-          return Right(new Op.Binary(BinaryOp.GreaterOrEqual));
+          return Result.ok(new Op.Binary(BinaryOp.GreaterOrEqual));
         case Equal:
-          return Right(new Op.Binary(BinaryOp.Equal));
+          return Result.ok(new Op.Binary(BinaryOp.Equal));
         case NotEqual:
-          return Right(new Op.Binary(BinaryOp.NotEqual));
+          return Result.ok(new Op.Binary(BinaryOp.NotEqual));
         case Contains:
-          return Right(new Op.Binary(BinaryOp.Contains));
+          return Result.ok(new Op.Binary(BinaryOp.Contains));
         case Prefix:
-          return Right(new Op.Binary(BinaryOp.Prefix));
+          return Result.ok(new Op.Binary(BinaryOp.Prefix));
         case Suffix:
-          return Right(new Op.Binary(BinaryOp.Suffix));
+          return Result.ok(new Op.Binary(BinaryOp.Suffix));
         case Regex:
-          return Right(new Op.Binary(BinaryOp.Regex));
+          return Result.ok(new Op.Binary(BinaryOp.Regex));
         case Add:
-          return Right(new Op.Binary(BinaryOp.Add));
+          return Result.ok(new Op.Binary(BinaryOp.Add));
         case Sub:
-          return Right(new Op.Binary(BinaryOp.Sub));
+          return Result.ok(new Op.Binary(BinaryOp.Sub));
         case Mul:
-          return Right(new Op.Binary(BinaryOp.Mul));
+          return Result.ok(new Op.Binary(BinaryOp.Mul));
         case Div:
-          return Right(new Op.Binary(BinaryOp.Div));
+          return Result.ok(new Op.Binary(BinaryOp.Div));
         case And:
-          return Right(new Op.Binary(BinaryOp.And));
+          return Result.ok(new Op.Binary(BinaryOp.And));
         case Or:
-          return Right(new Op.Binary(BinaryOp.Or));
+          return Result.ok(new Op.Binary(BinaryOp.Or));
         case Intersection:
-          return Right(new Op.Binary(BinaryOp.Intersection));
+          return Result.ok(new Op.Binary(BinaryOp.Intersection));
         case Union:
-          return Right(new Op.Binary(BinaryOp.Union));
+          return Result.ok(new Op.Binary(BinaryOp.Union));
         case BitwiseAnd:
-          return Right(new Op.Binary(BinaryOp.BitwiseAnd));
+          return Result.ok(new Op.Binary(BinaryOp.BitwiseAnd));
         case BitwiseOr:
-          return Right(new Op.Binary(BinaryOp.BitwiseOr));
+          return Result.ok(new Op.Binary(BinaryOp.BitwiseOr));
         case BitwiseXor:
-          return Right(new Op.Binary(BinaryOp.BitwiseXor));
+          return Result.ok(new Op.Binary(BinaryOp.BitwiseXor));
         default:
-          return Left(
+          return Result.err(
               new Error.FormatError.DeserializationError(
                   "invalid binary operation: " + op.getKind()));
       }

--- a/src/main/java/org/eclipse/biscuit/datalog/expressions/Op.java
+++ b/src/main/java/org/eclipse/biscuit/datalog/expressions/Op.java
@@ -12,12 +12,12 @@ import biscuit.format.schema.Schema;
 import com.google.re2j.Matcher;
 import com.google.re2j.Pattern;
 import io.vavr.control.Either;
-import io.vavr.control.Option;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.eclipse.biscuit.datalog.SymbolTable;
 import org.eclipse.biscuit.datalog.TemporarySymbolTable;
@@ -150,7 +150,7 @@ public abstract class Op {
           break;
         case Length:
           if (value instanceof Term.Str) {
-            Option<String> s = temporarySymbolTable.getSymbol((int) ((Term.Str) value).value());
+            Optional<String> s = temporarySymbolTable.getSymbol((int) ((Term.Str) value).value());
             if (s.isEmpty()) {
               throw new Error.Execution("string not found in symbols for id" + value);
             } else {
@@ -405,8 +405,9 @@ public abstract class Op {
             stack.push(new Term.Bool(leftSet.containsAll(rightSet)));
           }
           if (left instanceof Term.Str && right instanceof Term.Str) {
-            Option<String> leftS = temporarySymbolTable.getSymbol((int) ((Term.Str) left).value());
-            Option<String> rightS =
+            Optional<String> leftS =
+                temporarySymbolTable.getSymbol((int) ((Term.Str) left).value());
+            Optional<String> rightS =
                 temporarySymbolTable.getSymbol((int) ((Term.Str) right).value());
 
             if (leftS.isEmpty()) {
@@ -423,8 +424,9 @@ public abstract class Op {
           break;
         case Prefix:
           if (right instanceof Term.Str && left instanceof Term.Str) {
-            Option<String> leftS = temporarySymbolTable.getSymbol((int) ((Term.Str) left).value());
-            Option<String> rightS =
+            Optional<String> leftS =
+                temporarySymbolTable.getSymbol((int) ((Term.Str) left).value());
+            Optional<String> rightS =
                 temporarySymbolTable.getSymbol((int) ((Term.Str) right).value());
             if (leftS.isEmpty()) {
               throw new Error.Execution(
@@ -440,8 +442,9 @@ public abstract class Op {
           break;
         case Suffix:
           if (right instanceof Term.Str && left instanceof Term.Str) {
-            Option<String> leftS = temporarySymbolTable.getSymbol((int) ((Term.Str) left).value());
-            Option<String> rightS =
+            Optional<String> leftS =
+                temporarySymbolTable.getSymbol((int) ((Term.Str) left).value());
+            Optional<String> rightS =
                 temporarySymbolTable.getSymbol((int) ((Term.Str) right).value());
             if (leftS.isEmpty()) {
               throw new Error.Execution(
@@ -456,8 +459,9 @@ public abstract class Op {
           break;
         case Regex:
           if (right instanceof Term.Str && left instanceof Term.Str) {
-            Option<String> leftS = temporarySymbolTable.getSymbol((int) ((Term.Str) left).value());
-            Option<String> rightS =
+            Optional<String> leftS =
+                temporarySymbolTable.getSymbol((int) ((Term.Str) left).value());
+            Optional<String> rightS =
                 temporarySymbolTable.getSymbol((int) ((Term.Str) right).value());
             if (leftS.isEmpty()) {
               throw new Error.Execution(
@@ -485,8 +489,9 @@ public abstract class Op {
             }
           }
           if (right instanceof Term.Str && left instanceof Term.Str) {
-            Option<String> leftS = temporarySymbolTable.getSymbol((int) ((Term.Str) left).value());
-            Option<String> rightS =
+            Optional<String> leftS =
+                temporarySymbolTable.getSymbol((int) ((Term.Str) left).value());
+            Optional<String> rightS =
                 temporarySymbolTable.getSymbol((int) ((Term.Str) right).value());
 
             if (leftS.isEmpty()) {

--- a/src/main/java/org/eclipse/biscuit/error/Error.java
+++ b/src/main/java/org/eclipse/biscuit/error/Error.java
@@ -10,16 +10,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import io.vavr.control.Option;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import org.eclipse.biscuit.datalog.expressions.Expression;
 
 public abstract class Error extends Exception {
   static final ObjectMapper objectMapper = new ObjectMapper();
 
-  public Option<List<FailedCheck>> getFailedChecks() {
-    return Option.none();
+  public Optional<List<FailedCheck>> getFailedChecks() {
+    return Optional.empty();
   }
 
   /**
@@ -626,7 +626,7 @@ public abstract class Error extends Exception {
     }
 
     @Override
-    public Option<List<FailedCheck>> getFailedChecks() {
+    public Optional<List<FailedCheck>> getFailedChecks() {
       return this.error.getFailedChecks();
     }
 

--- a/src/main/java/org/eclipse/biscuit/error/Error.java
+++ b/src/main/java/org/eclipse/biscuit/error/Error.java
@@ -5,15 +5,19 @@
 
 package org.eclipse.biscuit.error;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import io.vavr.control.Option;
 import java.util.List;
 import java.util.Objects;
 import org.eclipse.biscuit.datalog.expressions.Expression;
 
-public class Error extends Exception {
+public abstract class Error extends Exception {
+  static final ObjectMapper objectMapper = new ObjectMapper();
+
   public Option<List<FailedCheck>> getFailedChecks() {
     return Option.none();
   }
@@ -23,25 +27,24 @@ public class Error extends Exception {
    *
    * @return json object
    */
-  public JsonElement toJson() {
-    return new JsonObject();
+  public abstract JsonNode toJson();
+
+  public static final class InternalError extends Error {
+    @Override
+    public JsonNode toJson() {
+      return TextNode.valueOf("InternalError");
+    }
   }
 
-  public static final class InternalError extends Error {}
+  public abstract static class FormatError extends Error {
 
-  public static class FormatError extends Error {
-
-    private static JsonElement jsonWrapper(JsonElement e) {
-      JsonObject root = new JsonObject();
-      root.add("Format", e);
-      return root;
+    private static JsonNode jsonWrapper(JsonNode e) {
+      return objectMapper.createObjectNode().set("Format", e);
     }
 
-    public static class Signature extends FormatError {
-      private static JsonElement jsonWrapper(JsonElement e) {
-        JsonObject signature = new JsonObject();
-        signature.add("Signature", e);
-        return FormatError.jsonWrapper(signature);
+    public abstract static class Signature extends FormatError {
+      private static JsonNode jsonWrapper(JsonNode e) {
+        return FormatError.jsonWrapper(objectMapper.createObjectNode().set("Signature", e));
       }
 
       public static final class InvalidFormat extends Signature {
@@ -56,8 +59,8 @@ public class Error extends Exception {
         }
 
         @Override
-        public JsonElement toJson() {
-          return Signature.jsonWrapper(new JsonPrimitive("InvalidFormat"));
+        public JsonNode toJson() {
+          return Signature.jsonWrapper(TextNode.valueOf("InvalidFormat"));
         }
 
         @Override
@@ -82,10 +85,9 @@ public class Error extends Exception {
         }
 
         @Override
-        public JsonElement toJson() {
-          JsonObject jo = new JsonObject();
-          jo.addProperty("InvalidSignature", this.err);
-          return Signature.jsonWrapper(jo);
+        public JsonNode toJson() {
+          return Signature.jsonWrapper(
+              objectMapper.createObjectNode().put("InvalidSignature", this.err));
         }
 
         @Override
@@ -105,8 +107,8 @@ public class Error extends Exception {
       }
 
       @Override
-      public JsonElement toJson() {
-        return FormatError.jsonWrapper(new JsonPrimitive("SealedSignature"));
+      public JsonNode toJson() {
+        return Signature.jsonWrapper(TextNode.valueOf("SealedSignature"));
       }
 
       @Override
@@ -125,8 +127,8 @@ public class Error extends Exception {
       }
 
       @Override
-      public JsonElement toJson() {
-        return FormatError.jsonWrapper(new JsonPrimitive("EmptyKeys"));
+      public JsonNode toJson() {
+        return Signature.jsonWrapper(TextNode.valueOf("EmptyKeys"));
       }
 
       @Override
@@ -145,8 +147,8 @@ public class Error extends Exception {
       }
 
       @Override
-      public JsonElement toJson() {
-        return FormatError.jsonWrapper(new JsonPrimitive("UnknownPublicKey"));
+      public JsonNode toJson() {
+        return Signature.jsonWrapper(TextNode.valueOf("UnknownPublicKey"));
       }
 
       @Override
@@ -185,10 +187,9 @@ public class Error extends Exception {
       }
 
       @Override
-      public JsonElement toJson() {
-        JsonObject jo = new JsonObject();
-        jo.addProperty("DeserializationError", this.err);
-        return FormatError.jsonWrapper(jo);
+      public JsonNode toJson() {
+        return FormatError.jsonWrapper(
+            objectMapper.createObjectNode().put("DeserializationError", this.err));
       }
     }
 
@@ -222,10 +223,9 @@ public class Error extends Exception {
       }
 
       @Override
-      public JsonElement toJson() {
-        JsonObject jo = new JsonObject();
-        jo.addProperty("SerializationError", this.err);
-        return FormatError.jsonWrapper(jo);
+      public JsonNode toJson() {
+        return FormatError.jsonWrapper(
+            objectMapper.createObjectNode().put("SerializationError", this.err));
       }
     }
 
@@ -259,10 +259,9 @@ public class Error extends Exception {
       }
 
       @Override
-      public JsonElement toJson() {
-        JsonObject jo = new JsonObject();
-        jo.addProperty("BlockDeserializationError", this.err);
-        return FormatError.jsonWrapper(jo);
+      public JsonNode toJson() {
+        return FormatError.jsonWrapper(
+            objectMapper.createObjectNode().put("BlockDeserializationError", this.err));
       }
     }
 
@@ -296,10 +295,9 @@ public class Error extends Exception {
       }
 
       @Override
-      public JsonElement toJson() {
-        JsonObject jo = new JsonObject();
-        jo.addProperty("BlockSerializationError", this.err);
-        return FormatError.jsonWrapper(jo);
+      public JsonNode toJson() {
+        return FormatError.jsonWrapper(
+            objectMapper.createObjectNode().put("BlockSerializationError", this.err));
       }
     }
 
@@ -352,14 +350,14 @@ public class Error extends Exception {
       }
 
       @Override
-      public JsonElement toJson() {
-        JsonObject child = new JsonObject();
-        child.addProperty("minimum", this.minimum);
-        child.addProperty("maximum", this.maximum);
-        child.addProperty("actual", this.actual);
-        JsonObject jo = new JsonObject();
-        jo.add("Version", child);
-        return FormatError.jsonWrapper(jo);
+      public JsonNode toJson() {
+        ObjectNode child =
+            objectMapper
+                .createObjectNode()
+                .put("minimum", this.minimum)
+                .put("maximum", this.maximum)
+                .put("actual", this.actual);
+        return FormatError.jsonWrapper(objectMapper.createObjectNode().set("Version", child));
       }
     }
 
@@ -395,10 +393,9 @@ public class Error extends Exception {
       }
 
       @Override
-      public JsonElement toJson() {
-        JsonObject jo = new JsonObject();
-        jo.add("InvalidSignatureSize", new JsonPrimitive(size));
-        return FormatError.jsonWrapper(jo);
+      public JsonNode toJson() {
+        return FormatError.jsonWrapper(
+            objectMapper.createObjectNode().set("InvalidSignatureSize", IntNode.valueOf(size)));
       }
     }
 
@@ -434,10 +431,9 @@ public class Error extends Exception {
       }
 
       @Override
-      public JsonElement toJson() {
-        JsonObject jo = new JsonObject();
-        jo.add("InvalidKeySize", new JsonPrimitive(size));
-        return FormatError.jsonWrapper(jo);
+      public JsonNode toJson() {
+        return FormatError.jsonWrapper(
+            objectMapper.createObjectNode().set("InvalidKeySize", IntNode.valueOf(size)));
       }
     }
 
@@ -471,10 +467,9 @@ public class Error extends Exception {
       }
 
       @Override
-      public JsonElement toJson() {
-        JsonObject jo = new JsonObject();
-        jo.addProperty("InvalidKey", this.err);
-        return FormatError.jsonWrapper(jo);
+      public JsonNode toJson() {
+        return FormatError.jsonWrapper(
+            objectMapper.createObjectNode().set("InvalidKey", TextNode.valueOf(this.err)));
       }
     }
   }
@@ -509,12 +504,10 @@ public class Error extends Exception {
     }
 
     @Override
-    public JsonElement toJson() {
-      JsonObject child = new JsonObject();
-      child.addProperty("index", this.index);
-      JsonObject jo = new JsonObject();
-      jo.add("InvalidAuthorityIndex", child);
-      return jo;
+    public JsonNode toJson() {
+      ObjectNode child = objectMapper.createObjectNode().put("index", index);
+      return FormatError.jsonWrapper(
+          objectMapper.createObjectNode().set("InvalidAuthorityIndex", child));
     }
   }
 
@@ -550,13 +543,11 @@ public class Error extends Exception {
     }
 
     @Override
-    public JsonElement toJson() {
-      JsonObject child = new JsonObject();
-      child.addProperty("expected", this.expected);
-      child.addProperty("fount", this.found);
-      JsonObject jo = new JsonObject();
-      jo.add("InvalidBlockIndex", child);
-      return jo;
+    public JsonNode toJson() {
+      ObjectNode child =
+          objectMapper.createObjectNode().put("expected", expected).put("found", found);
+      return FormatError.jsonWrapper(
+          objectMapper.createObjectNode().set("InvalidBlockIndex", child));
     }
   }
 
@@ -570,8 +561,8 @@ public class Error extends Exception {
     }
 
     @Override
-    public JsonElement toJson() {
-      return new JsonPrimitive("SymbolTableOverlap");
+    public JsonNode toJson() {
+      return TextNode.valueOf("SymbolTableOverlap");
     }
   }
 
@@ -585,8 +576,8 @@ public class Error extends Exception {
     }
 
     @Override
-    public JsonElement toJson() {
-      return new JsonPrimitive("MissingSymbols");
+    public JsonNode toJson() {
+      return TextNode.valueOf("MissingSymbols");
     }
   }
 
@@ -600,8 +591,8 @@ public class Error extends Exception {
     }
 
     @Override
-    public JsonElement toJson() {
-      return new JsonPrimitive("Sealed");
+    public JsonNode toJson() {
+      return TextNode.valueOf("Sealed");
     }
   }
 
@@ -640,10 +631,8 @@ public class Error extends Exception {
     }
 
     @Override
-    public JsonElement toJson() {
-      JsonObject jo = new JsonObject();
-      jo.add("FailedLogic", this.error.toJson());
-      return jo;
+    public JsonNode toJson() {
+      return objectMapper.createObjectNode().set("FailedLogic", error.toJson());
     }
   }
 
@@ -663,10 +652,8 @@ public class Error extends Exception {
     }
 
     @Override
-    public JsonElement toJson() {
-      JsonObject jo = new JsonObject();
-      jo.add("Language", langError.toJson());
-      return jo;
+    public JsonNode toJson() {
+      return objectMapper.createObjectNode().set("Language", langError.toJson());
     }
   }
 
@@ -680,8 +667,8 @@ public class Error extends Exception {
     }
 
     @Override
-    public JsonElement toJson() {
-      return new JsonPrimitive("TooManyFacts");
+    public JsonNode toJson() {
+      return TextNode.valueOf("TooManyFacts");
     }
   }
 
@@ -695,8 +682,8 @@ public class Error extends Exception {
     }
 
     @Override
-    public JsonElement toJson() {
-      return new JsonPrimitive("TooManyIterations");
+    public JsonNode toJson() {
+      return TextNode.valueOf("TooManyIterations");
     }
   }
 
@@ -710,8 +697,8 @@ public class Error extends Exception {
     }
 
     @Override
-    public JsonElement toJson() {
-      return new JsonPrimitive("Timeout");
+    public JsonNode toJson() {
+      return TextNode.valueOf("Timeout");
     }
   }
 
@@ -753,10 +740,8 @@ public class Error extends Exception {
     }
 
     @Override
-    public JsonElement toJson() {
-      JsonObject jo = new JsonObject();
-      jo.add("Execution", new JsonPrimitive(this.kind.toString()));
-      return jo;
+    public JsonNode toJson() {
+      return objectMapper.createObjectNode().put("Execution", kind.toString());
     }
 
     @Override
@@ -775,8 +760,8 @@ public class Error extends Exception {
     }
 
     @Override
-    public JsonElement toJson() {
-      return new JsonPrimitive("InvalidType");
+    public JsonNode toJson() {
+      return TextNode.valueOf("InvalidType");
     }
   }
 
@@ -812,10 +797,8 @@ public class Error extends Exception {
     }
 
     @Override
-    public JsonElement toJson() {
-      JsonObject error = new JsonObject();
-      error.add("error", this.error.toJson());
-      return error;
+    public JsonNode toJson() {
+      return objectMapper.createObjectNode().set("error", objectMapper.valueToTree(error));
     }
   }
 }

--- a/src/main/java/org/eclipse/biscuit/error/LogicError.java
+++ b/src/main/java/org/eclipse/biscuit/error/LogicError.java
@@ -10,15 +10,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
-import io.vavr.control.Option;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 public abstract class LogicError {
   static final ObjectMapper objectMapper = new ObjectMapper();
 
-  public Option<List<FailedCheck>> getFailedChecks() {
-    return Option.none();
+  public Optional<List<FailedCheck>> getFailedChecks() {
+    return Optional.empty();
   }
 
   public abstract JsonNode toJson();
@@ -181,8 +181,8 @@ public abstract class LogicError {
       this.policy = policy;
     }
 
-    public Option<List<FailedCheck>> getFailedChecks() {
-      return Option.some(errors);
+    public Optional<List<FailedCheck>> getFailedChecks() {
+      return Optional.of(errors);
     }
 
     @Override
@@ -242,8 +242,8 @@ public abstract class LogicError {
     }
 
     @Override
-    public Option<List<FailedCheck>> getFailedChecks() {
-      return Option.some(errors);
+    public Optional<List<FailedCheck>> getFailedChecks() {
+      return Optional.of(errors);
     }
 
     @Override

--- a/src/main/java/org/eclipse/biscuit/error/LogicError.java
+++ b/src/main/java/org/eclipse/biscuit/error/LogicError.java
@@ -5,22 +5,23 @@
 
 package org.eclipse.biscuit.error;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonPrimitive;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
 import io.vavr.control.Option;
 import java.util.List;
 import java.util.Objects;
 
-public class LogicError {
+public abstract class LogicError {
+  static final ObjectMapper objectMapper = new ObjectMapper();
+
   public Option<List<FailedCheck>> getFailedChecks() {
     return Option.none();
   }
 
-  public JsonElement toJson() {
-    return new JsonObject();
-  }
+  public abstract JsonNode toJson();
 
   public static final class InvalidAuthorityFact extends LogicError {
     public final String err;
@@ -52,8 +53,8 @@ public class LogicError {
     }
 
     @Override
-    public JsonElement toJson() {
-      return new JsonPrimitive("InvalidAuthorityFact");
+    public JsonNode toJson() {
+      return TextNode.valueOf("InvalidAuthorityFact");
     }
   }
 
@@ -87,12 +88,9 @@ public class LogicError {
     }
 
     @Override
-    public JsonElement toJson() {
-      JsonObject child = new JsonObject();
-      child.addProperty("error", this.err);
-      JsonObject root = new JsonObject();
-      root.add("InvalidAmbientFact", child);
-      return root;
+    public JsonNode toJson() {
+      ObjectNode child = objectMapper.createObjectNode().put("error", this.err);
+      return objectMapper.createObjectNode().set("InvalidAmbientFact", child);
     }
   }
 
@@ -128,13 +126,9 @@ public class LogicError {
     }
 
     @Override
-    public JsonElement toJson() {
-      JsonObject child = new JsonObject();
-      child.addProperty("id", this.id);
-      child.addProperty("error", this.err);
-      JsonObject root = new JsonObject();
-      root.add("InvalidBlockFact", child);
-      return root;
+    public JsonNode toJson() {
+      ObjectNode child = objectMapper.createObjectNode().put("id", id).put("error", err);
+      return objectMapper.createObjectNode().set("InvalidBlockFact", child);
     }
   }
 
@@ -170,13 +164,11 @@ public class LogicError {
     }
 
     @Override
-    public JsonElement toJson() {
-      JsonArray child = new JsonArray();
-      child.add(this.id);
-      child.add(this.err);
-      JsonObject root = new JsonObject();
-      root.add("InvalidBlockRule", child);
-      return root;
+    public JsonNode toJson() {
+      ArrayNode child = objectMapper.createArrayNode();
+      child.add(id);
+      child.add(err);
+      return objectMapper.createObjectNode().set("InvalidBlockRule", child);
     }
   }
 
@@ -224,17 +216,16 @@ public class LogicError {
     }
 
     @Override
-    public JsonElement toJson() {
-      JsonObject unauthorized = new JsonObject();
-      unauthorized.add("policy", this.policy.toJson());
-      JsonArray ja = new JsonArray();
+    public JsonNode toJson() {
+      ArrayNode checks = objectMapper.createArrayNode();
       for (FailedCheck t : this.errors) {
-        ja.add(t.toJson());
+        checks.add(t.toJson());
       }
-      unauthorized.add("checks", ja);
-      JsonObject jo = new JsonObject();
-      jo.add("Unauthorized", unauthorized);
-      return jo;
+
+      ObjectNode unauthorized = objectMapper.createObjectNode();
+      unauthorized.set("policy", policy.toJson());
+      unauthorized.set("checks", checks);
+      return objectMapper.createObjectNode().set("Unauthorized", unauthorized);
     }
   }
 
@@ -282,14 +273,12 @@ public class LogicError {
     }
 
     @Override
-    public JsonElement toJson() {
-      JsonObject jo = new JsonObject();
-      JsonArray ja = new JsonArray();
+    public JsonNode toJson() {
+      ArrayNode errors = objectMapper.createArrayNode();
       for (FailedCheck t : this.errors) {
-        ja.add(t.toJson());
+        errors.add(t.toJson());
       }
-      jo.add("NoMatchingPolicy", ja);
-      return jo;
+      return objectMapper.createObjectNode().set("NoMatchingPolicy", errors);
     }
   }
 
@@ -298,13 +287,8 @@ public class LogicError {
     public AuthorizerNotEmpty() {}
 
     @Override
-    public int hashCode() {
-      return super.hashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      return super.equals(obj);
+    public JsonNode toJson() {
+      return TextNode.valueOf("AuthorizerNotEmpty");
     }
 
     @Override
@@ -314,7 +298,7 @@ public class LogicError {
   }
 
   public abstract static class MatchedPolicy {
-    public abstract JsonElement toJson();
+    public abstract JsonNode toJson();
 
     public static final class Allow extends MatchedPolicy {
       public final long nb;
@@ -328,10 +312,9 @@ public class LogicError {
         return "Allow(" + this.nb + ")";
       }
 
-      public JsonElement toJson() {
-        JsonObject jo = new JsonObject();
-        jo.addProperty("Allow", this.nb);
-        return jo;
+      @Override
+      public JsonNode toJson() {
+        return objectMapper.createObjectNode().put("Allow", nb);
       }
     }
 
@@ -347,10 +330,9 @@ public class LogicError {
         return "Deny(" + this.nb + ")";
       }
 
-      public JsonElement toJson() {
-        JsonObject jo = new JsonObject();
-        jo.addProperty("Deny", this.nb);
-        return jo;
+      @Override
+      public JsonNode toJson() {
+        return objectMapper.createObjectNode().put("Deny", nb);
       }
     }
   }

--- a/src/main/java/org/eclipse/biscuit/error/Result.java
+++ b/src/main/java/org/eclipse/biscuit/error/Result.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2019 Geoffroy Couprie <contact@geoffroycouprie.com> and Contributors to the Eclipse Foundation.
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.eclipse.biscuit.error;
+
+import java.util.Objects;
+
+public abstract class Result<T, E> {
+  public boolean isOk() {
+    return false;
+  }
+
+  public boolean isErr() {
+    return false;
+  }
+
+  public T getOk() {
+    throw new IllegalStateException("Result is not ok");
+  }
+
+  public E getErr() {
+    throw new IllegalStateException("Result is not error");
+  }
+
+  private static final class Ok<T, E> extends Result<T, E> {
+    T okValue;
+
+    Ok(T okValue) {
+      this.okValue = okValue;
+    }
+
+    @Override
+    public boolean isOk() {
+      return true;
+    }
+
+    @Override
+    public T getOk() {
+      return okValue;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj == this || obj instanceof Ok && Objects.equals(okValue, ((Ok<?, ?>) obj).okValue);
+    }
+  }
+
+  private static final class Err<T, E> extends Result<T, E> {
+    E errorValue;
+
+    Err(E errorValue) {
+      this.errorValue = errorValue;
+    }
+
+    @Override
+    public boolean isErr() {
+      return true;
+    }
+
+    @Override
+    public E getErr() {
+      return errorValue;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj == this
+          || obj instanceof Err && Objects.equals(errorValue, ((Err<?, ?>) obj).errorValue);
+    }
+  }
+
+  public static <T, E> Result<T, E> ok(T okValue) {
+    return new Ok<>(okValue);
+  }
+
+  public static <T, E> Result<T, E> err(E errorValue) {
+    return new Err<>(errorValue);
+  }
+}

--- a/src/main/java/org/eclipse/biscuit/token/Authorizer.java
+++ b/src/main/java/org/eclipse/biscuit/token/Authorizer.java
@@ -258,16 +258,11 @@ public final class Authorizer {
   }
 
   public Authorizer addFact(String s) throws Error.Parser {
-    Either<org.eclipse.biscuit.token.builder.parser.Error, Tuple2<String, Fact>> res =
-        Parser.fact(s);
-
-    if (res.isLeft()) {
-      throw new Error.Parser(res.getLeft());
+    var res = Parser.fact(s);
+    if (res.isErr()) {
+      throw new Error.Parser(res.getErr());
     }
-
-    Tuple2<String, Fact> t = res.get();
-
-    return this.addFact(t._2);
+    return this.addFact(res.getOk()._2);
   }
 
   public Authorizer addRule(Rule rule) {
@@ -280,16 +275,11 @@ public final class Authorizer {
   }
 
   public Authorizer addRule(String s) throws Error.Parser {
-    Either<org.eclipse.biscuit.token.builder.parser.Error, Tuple2<String, Rule>> res =
-        Parser.rule(s);
-
-    if (res.isLeft()) {
-      throw new Error.Parser(res.getLeft());
+    var res = Parser.rule(s);
+    if (res.isErr()) {
+      throw new Error.Parser(res.getErr());
     }
-
-    Tuple2<String, Rule> t = res.get();
-
-    return addRule(t._2);
+    return addRule(res.getOk()._2);
   }
 
   public TrustedOrigins authorizerTrustedOrigins() {
@@ -303,16 +293,11 @@ public final class Authorizer {
   }
 
   public Authorizer addCheck(String s) throws Error.Parser {
-    Either<org.eclipse.biscuit.token.builder.parser.Error, Tuple2<String, Check>> res =
-        Parser.check(s);
-
-    if (res.isLeft()) {
-      throw new Error.Parser(res.getLeft());
+    var res = Parser.check(s);
+    if (res.isErr()) {
+      throw new Error.Parser(res.getErr());
     }
-
-    Tuple2<String, Check> t = res.get();
-
-    return addCheck(t._2);
+    return addCheck(res.getOk()._2);
   }
 
   public Authorizer setTime() throws Error.Language {
@@ -375,16 +360,11 @@ public final class Authorizer {
   }
 
   public Authorizer addPolicy(String s) throws Error.Parser {
-    Either<org.eclipse.biscuit.token.builder.parser.Error, Tuple2<String, Policy>> res =
-        Parser.policy(s);
-
-    if (res.isLeft()) {
-      throw new Error.Parser(res.getLeft());
+    var res = Parser.policy(s);
+    if (res.isErr()) {
+      throw new Error.Parser(res.getErr());
     }
-
-    Tuple2<String, Policy> t = res.get();
-
-    this.policies.add(t._2);
+    this.policies.add(res.getOk()._2);
     return this;
   }
 
@@ -402,17 +382,12 @@ public final class Authorizer {
     return this.query(query, new RunLimits());
   }
 
-  public Set<Fact> query(String s) throws Error {
-    Either<org.eclipse.biscuit.token.builder.parser.Error, Tuple2<String, Rule>> res =
-        Parser.rule(s);
-
-    if (res.isLeft()) {
-      throw new Error.Parser(res.getLeft());
+  public Set<org.eclipse.biscuit.token.builder.Fact> query(String s) throws Error {
+    var res = Parser.rule(s);
+    if (res.isErr()) {
+      throw new Error.Parser(res.getErr());
     }
-
-    Tuple2<String, Rule> t = res.get();
-
-    return query(t._2);
+    return query(res.getOk()._2);
   }
 
   public Set<Fact> query(Rule query, RunLimits limits) throws Error {
@@ -438,17 +413,13 @@ public final class Authorizer {
     return s;
   }
 
-  public Set<Fact> query(String s, RunLimits limits) throws Error {
-    Either<org.eclipse.biscuit.token.builder.parser.Error, Tuple2<String, Rule>> res =
-        Parser.rule(s);
-
-    if (res.isLeft()) {
-      throw new Error.Parser(res.getLeft());
+  public Set<org.eclipse.biscuit.token.builder.Fact> query(String s, RunLimits limits)
+      throws Error {
+    var res = Parser.rule(s);
+    if (res.isErr()) {
+      throw new Error.Parser(res.getErr());
     }
-
-    Tuple2<String, Rule> t = res.get();
-
-    return query(t._2, limits);
+    return query(res.getOk()._2, limits);
   }
 
   public Long authorize() throws Error {

--- a/src/main/java/org/eclipse/biscuit/token/Authorizer.java
+++ b/src/main/java/org/eclipse/biscuit/token/Authorizer.java
@@ -11,7 +11,6 @@ import static io.vavr.API.Right;
 import io.vavr.Tuple2;
 import io.vavr.Tuple5;
 import io.vavr.control.Either;
-import io.vavr.control.Option;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
@@ -21,6 +20,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.eclipse.biscuit.crypto.PublicKey;
@@ -120,7 +120,7 @@ public final class Authorizer {
       for (long i = 0; i < token.blocks.size(); i++) {
         Block block = token.blocks.get((int) i);
 
-        if (block.getExternalKey().isDefined()) {
+        if (block.getExternalKey().isPresent()) {
           PublicKey pk = block.getExternalKey().get();
           long newKeyId = this.symbolTable.insert(pk);
           if (!this.publicKeyToBlockId.containsKey(newKeyId)) {
@@ -168,7 +168,7 @@ public final class Authorizer {
 
         SymbolTable blockSymbolTable = token.symbolTable;
 
-        if (block.getExternalKey().isDefined()) {
+        if (block.getExternalKey().isPresent()) {
           blockSymbolTable = new SymbolTable(block.getSymbolTable(), block.getPublicKeys());
         }
 
@@ -546,7 +546,7 @@ public final class Authorizer {
       }
     }
 
-    Option<Either<Integer, Integer>> policyResult = Option.none();
+    Optional<Either<Integer, Integer>> policyResult = Optional.empty();
     policies_test:
     for (int i = 0; i < this.policies.size(); i++) {
       Policy policy = this.policies.get(i);
@@ -564,9 +564,9 @@ public final class Authorizer {
 
         if (res) {
           if (this.policies.get(i).kind() == Policy.Kind.ALLOW) {
-            policyResult = Option.some(Right(i));
+            policyResult = Optional.of(Right(i));
           } else {
-            policyResult = Option.some(Left(i));
+            policyResult = Optional.of(Left(i));
           }
           break policies_test;
         }
@@ -580,7 +580,7 @@ public final class Authorizer {
             TrustedOrigins.fromScopes(
                 b.getScopes(), TrustedOrigins.defaultOrigins(), i + 1, this.publicKeyToBlockId);
         SymbolTable blockSymbolTable = token.symbolTable;
-        if (b.getExternalKey().isDefined()) {
+        if (b.getExternalKey().isPresent()) {
           blockSymbolTable = new SymbolTable(b.getSymbolTable(), b.getPublicKeys());
         }
 
@@ -624,7 +624,7 @@ public final class Authorizer {
       }
     }
 
-    if (policyResult.isDefined()) {
+    if (policyResult.isPresent()) {
       Either<Integer, Integer> e = policyResult.get();
       if (e.isRight()) {
         if (errors.isEmpty()) {
@@ -676,7 +676,7 @@ public final class Authorizer {
         Block b = this.token.blocks.get(i);
 
         SymbolTable blockSymbolTable = token.symbolTable;
-        if (b.getExternalKey().isDefined()) {
+        if (b.getExternalKey().isPresent()) {
           blockSymbolTable = new SymbolTable(b.getSymbolTable(), b.getPublicKeys());
         }
 
@@ -735,7 +735,7 @@ public final class Authorizer {
     for (Block block : this.token.blocks) {
       List<Check> blockChecks = new ArrayList<>();
 
-      if (block.getExternalKey().isDefined()) {
+      if (block.getExternalKey().isPresent()) {
         SymbolTable blockSymbolTable =
             new SymbolTable(block.getSymbolTable(), block.getPublicKeys());
         for (org.eclipse.biscuit.datalog.Check check : block.getChecks()) {

--- a/src/main/java/org/eclipse/biscuit/token/Authorizer.java
+++ b/src/main/java/org/eclipse/biscuit/token/Authorizer.java
@@ -5,7 +5,6 @@
 
 package org.eclipse.biscuit.token;
 
-import io.vavr.Tuple2;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
@@ -21,6 +20,7 @@ import java.util.stream.Collectors;
 import org.eclipse.biscuit.crypto.PublicKey;
 import org.eclipse.biscuit.datalog.FactSet;
 import org.eclipse.biscuit.datalog.Origin;
+import org.eclipse.biscuit.datalog.Pair;
 import org.eclipse.biscuit.datalog.RuleSet;
 import org.eclipse.biscuit.datalog.RunLimits;
 import org.eclipse.biscuit.datalog.Scope;
@@ -670,10 +670,10 @@ public final class Authorizer {
     return this.world.getRules();
   }
 
-  public List<Tuple2<Long, List<Check>>> getChecks() {
-    List<Tuple2<Long, List<Check>>> allChecks = new ArrayList<>();
+  public List<Pair<Long, List<Check>>> getChecks() {
+    List<Pair<Long, List<Check>>> allChecks = new ArrayList<>();
     if (!this.checks.isEmpty()) {
-      allChecks.add(new Tuple2<>(Long.MAX_VALUE, this.checks));
+      allChecks.add(new Pair<>(Long.MAX_VALUE, this.checks));
     }
 
     List<Check> authorityChecks = new ArrayList<>();
@@ -681,7 +681,7 @@ public final class Authorizer {
       authorityChecks.add(Check.convertFrom(check, this.token.symbolTable));
     }
     if (!authorityChecks.isEmpty()) {
-      allChecks.add(new Tuple2<>((long) 0, authorityChecks));
+      allChecks.add(new Pair<>((long) 0, authorityChecks));
     }
 
     long count = 1;
@@ -700,7 +700,7 @@ public final class Authorizer {
         }
       }
       if (!blockChecks.isEmpty()) {
-        allChecks.add(new Tuple2<>(count, blockChecks));
+        allChecks.add(new Pair<>(count, blockChecks));
       }
       count += 1;
     }

--- a/src/main/java/org/eclipse/biscuit/token/Authorizer.java
+++ b/src/main/java/org/eclipse/biscuit/token/Authorizer.java
@@ -6,7 +6,6 @@
 package org.eclipse.biscuit.token;
 
 import io.vavr.Tuple2;
-import io.vavr.Tuple5;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
@@ -220,18 +219,12 @@ public final class Authorizer {
       return Result.err(errorMap);
     }
 
-    Tuple5<
-            List<Fact>,
-            List<Rule>,
-            List<Check>,
-            List<org.eclipse.biscuit.token.builder.Scope>,
-            List<Policy>>
-        components = result.getOk();
-    components._1.forEach(this::addFact);
-    components._2.forEach(this::addRule);
-    components._3.forEach(this::addCheck);
-    components._4.forEach(this::addScope);
-    components._5.forEach(this::addPolicy);
+    var components = result.getOk();
+    components.facts.forEach(this::addFact);
+    components.rules.forEach(this::addRule);
+    components.checks.forEach(this::addCheck);
+    components.scopes.forEach(this::addScope);
+    components.policies.forEach(this::addPolicy);
 
     return Result.ok(this);
   }

--- a/src/main/java/org/eclipse/biscuit/token/Biscuit.java
+++ b/src/main/java/org/eclipse/biscuit/token/Biscuit.java
@@ -6,7 +6,6 @@
 package org.eclipse.biscuit.token;
 
 import biscuit.format.schema.Schema.PublicKey.Algorithm;
-import io.vavr.Tuple2;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -19,6 +18,7 @@ import org.eclipse.biscuit.crypto.KeyDelegate;
 import org.eclipse.biscuit.crypto.KeyPair;
 import org.eclipse.biscuit.crypto.PublicKey;
 import org.eclipse.biscuit.crypto.Signer;
+import org.eclipse.biscuit.datalog.Pair;
 import org.eclipse.biscuit.datalog.SymbolTable;
 import org.eclipse.biscuit.error.Error;
 import org.eclipse.biscuit.token.format.SerializedBiscuit;
@@ -253,7 +253,7 @@ public final class Biscuit extends UnverifiedBiscuit {
    */
   static Biscuit fromSerializedBiscuit(SerializedBiscuit ser, SymbolTable symbolTable)
       throws Error {
-    Tuple2<Block, ArrayList<Block>> t = ser.extractBlocks(symbolTable);
+    Pair<Block, ArrayList<Block>> t = ser.extractBlocks(symbolTable);
     Block authority = t._1;
     ArrayList<Block> blocks = t._2;
 

--- a/src/main/java/org/eclipse/biscuit/token/Biscuit.java
+++ b/src/main/java/org/eclipse/biscuit/token/Biscuit.java
@@ -8,7 +8,6 @@ package org.eclipse.biscuit.token;
 import biscuit.format.schema.Schema.PublicKey.Algorithm;
 import io.vavr.Tuple2;
 import io.vavr.control.Either;
-import io.vavr.control.Option;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -16,6 +15,7 @@ import java.security.SignatureException;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import java.util.Optional;
 import org.eclipse.biscuit.crypto.KeyDelegate;
 import org.eclipse.biscuit.crypto.KeyPair;
 import org.eclipse.biscuit.crypto.PublicKey;
@@ -60,7 +60,9 @@ public final class Biscuit extends UnverifiedBiscuit {
    * @return
    */
   public static org.eclipse.biscuit.token.builder.Biscuit builder(
-      final SecureRandom rng, final Signer root, final Option<Integer> rootKeyId) {
+      final SecureRandom rng,
+      final org.eclipse.biscuit.crypto.Signer root,
+      final Optional<Integer> rootKeyId) {
     return new org.eclipse.biscuit.token.builder.Biscuit(rng, root, rootKeyId);
   }
 
@@ -74,7 +76,7 @@ public final class Biscuit extends UnverifiedBiscuit {
    */
   public static Biscuit make(final SecureRandom rng, final Signer root, final Block authority)
       throws Error.FormatError {
-    return Biscuit.make(rng, root, Option.none(), authority);
+    return Biscuit.make(rng, root, Optional.empty(), authority);
   }
 
   /**
@@ -88,7 +90,7 @@ public final class Biscuit extends UnverifiedBiscuit {
   public static Biscuit make(
       final SecureRandom rng, final Signer root, final Integer rootKeyId, final Block authority)
       throws Error.FormatError {
-    return Biscuit.make(rng, root, Option.of(rootKeyId), authority);
+    return Biscuit.make(rng, root, Optional.of(rootKeyId), authority);
   }
 
   /**
@@ -101,8 +103,8 @@ public final class Biscuit extends UnverifiedBiscuit {
    */
   private static Biscuit make(
       final SecureRandom rng,
-      final Signer root,
-      final Option<Integer> rootKeyId,
+      final org.eclipse.biscuit.crypto.Signer root,
+      final Optional<Integer> rootKeyId,
       final Block authority)
       throws Error.FormatError {
     ArrayList<Block> blocks = new ArrayList<>();
@@ -120,7 +122,7 @@ public final class Biscuit extends UnverifiedBiscuit {
     } else {
       SerializedBiscuit s = container.get();
 
-      Option<SerializedBiscuit> c = Option.some(s);
+      Optional<SerializedBiscuit> c = Optional.of(s);
       return new Biscuit(authority, blocks, authority.getSymbolTable(), s);
     }
   }
@@ -328,8 +330,7 @@ public final class Biscuit extends UnverifiedBiscuit {
       throw new Error.SymbolTableOverlap();
     }
 
-    Either<Error.FormatError, SerializedBiscuit> containerRes =
-        copiedBiscuit.serializedBiscuit.append(keypair, block, Option.none());
+    var containerRes = copiedBiscuit.serializedBiscuit.append(keypair, block, Optional.empty());
     if (containerRes.isLeft()) {
       throw containerRes.getLeft();
     }
@@ -375,7 +376,7 @@ public final class Biscuit extends UnverifiedBiscuit {
     s.append("\n\tblocks: [\n");
     for (Block b : this.blocks) {
       s.append("\t\t");
-      if (b.getExternalKey().isDefined()) {
+      if (b.getExternalKey().isPresent()) {
         s.append(b.print(b.getSymbolTable()));
       } else {
         s.append(b.print(this.symbolTable));

--- a/src/main/java/org/eclipse/biscuit/token/Biscuit.java
+++ b/src/main/java/org/eclipse/biscuit/token/Biscuit.java
@@ -7,7 +7,6 @@ package org.eclipse.biscuit.token;
 
 import biscuit.format.schema.Schema.PublicKey.Algorithm;
 import io.vavr.Tuple2;
-import io.vavr.control.Either;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -115,12 +114,11 @@ public final class Biscuit extends UnverifiedBiscuit {
       authority.getSymbolTable().insert(pk);
     }
 
-    Either<Error.FormatError, SerializedBiscuit> container =
-        SerializedBiscuit.make(root, rootKeyId, authority, next);
-    if (container.isLeft()) {
-      throw container.getLeft();
+    var container = SerializedBiscuit.make(root, rootKeyId, authority, next);
+    if (container.isErr()) {
+      throw container.getErr();
     } else {
-      SerializedBiscuit s = container.get();
+      SerializedBiscuit s = container.getOk();
 
       Optional<SerializedBiscuit> c = Optional.of(s);
       return new Biscuit(authority, blocks, authority.getSymbolTable(), s);
@@ -331,8 +329,8 @@ public final class Biscuit extends UnverifiedBiscuit {
     }
 
     var containerRes = copiedBiscuit.serializedBiscuit.append(keypair, block, Optional.empty());
-    if (containerRes.isLeft()) {
-      throw containerRes.getLeft();
+    if (containerRes.isErr()) {
+      throw containerRes.getErr();
     }
 
     SymbolTable symbolTable = new SymbolTable(copiedBiscuit.symbolTable);
@@ -350,7 +348,7 @@ public final class Biscuit extends UnverifiedBiscuit {
     }
     blocks.add(block);
 
-    SerializedBiscuit container = containerRes.get();
+    SerializedBiscuit container = containerRes.getOk();
 
     return new Biscuit(copiedBiscuit.authority, blocks, symbolTable, container);
   }

--- a/src/main/java/org/eclipse/biscuit/token/Block.java
+++ b/src/main/java/org/eclipse/biscuit/token/Block.java
@@ -11,13 +11,13 @@ import static io.vavr.API.Right;
 import biscuit.format.schema.Schema;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.vavr.control.Either;
-import io.vavr.control.Option;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import org.eclipse.biscuit.crypto.PublicKey;
 import org.eclipse.biscuit.datalog.Check;
 import org.eclipse.biscuit.datalog.Fact;
@@ -39,7 +39,7 @@ public final class Block {
   private final List<Check> checks;
   private final List<Scope> scopes;
   private final List<PublicKey> publicKeys;
-  private Option<PublicKey> externalKey;
+  private Optional<PublicKey> externalKey;
   private long version;
 
   /**
@@ -55,7 +55,7 @@ public final class Block {
     this.checks = new ArrayList<>();
     this.scopes = new ArrayList<>();
     this.publicKeys = new ArrayList<>();
-    this.externalKey = Option.none();
+    this.externalKey = Optional.empty();
   }
 
   /**
@@ -73,7 +73,7 @@ public final class Block {
       List<Check> checks,
       List<Scope> scopes,
       List<PublicKey> publicKeys,
-      Option<PublicKey> externalKey,
+      Optional<PublicKey> externalKey,
       int version) {
     this.symbolTable = baseSymbols;
     this.context = context;
@@ -91,7 +91,7 @@ public final class Block {
   }
 
   public void setExternalKey(PublicKey externalKey) {
-    this.externalKey = Option.some(externalKey);
+    this.externalKey = Optional.of(externalKey);
   }
 
   /**
@@ -104,7 +104,7 @@ public final class Block {
     StringBuilder s = new StringBuilder();
 
     SymbolTable localSymbols;
-    if (this.externalKey.isDefined()) {
+    if (this.externalKey.isPresent()) {
       localSymbols = new SymbolTable(this.symbolTable);
       for (PublicKey pk : symbolTable.getPublicKeys()) {
         localSymbols.insert(pk);
@@ -121,7 +121,7 @@ public final class Block {
     s.append(this.publicKeys);
     s.append("\n\t\tcontext: ");
     s.append(this.context);
-    if (this.externalKey.isDefined()) {
+    if (this.externalKey.isPresent()) {
       s.append("\n\t\texternal key: ");
       s.append(this.externalKey.get().toString());
     }
@@ -154,7 +154,7 @@ public final class Block {
     StringBuilder s = new StringBuilder();
 
     SymbolTable localSymbols;
-    if (this.externalKey.isDefined()) {
+    if (this.externalKey.isPresent()) {
       localSymbols = new SymbolTable(this.symbolTable);
       for (PublicKey pk : symbolTable.getPublicKeys()) {
         localSymbols.insert(pk);
@@ -253,7 +253,7 @@ public final class Block {
       }
     }
 
-    if (this.externalKey.isDefined()) {
+    if (this.externalKey.isPresent()) {
       return SerializedBiscuit.MAX_SCHEMA_VERSION;
 
     } else if (containsScopes || containsCheckAll || containsV4) {
@@ -286,7 +286,7 @@ public final class Block {
    * @return
    */
   public static Either<Error.FormatError, Block> deserialize(
-      Schema.Block b, Option<PublicKey> externalKey) {
+      Schema.Block b, Optional<PublicKey> externalKey) {
     int version = b.getVersion();
     if (version < SerializedBiscuit.MIN_SCHEMA_VERSION
         || version > SerializedBiscuit.MAX_SCHEMA_VERSION) {
@@ -383,7 +383,7 @@ public final class Block {
    * @return
    */
   public static Either<Error.FormatError, Block> fromBytes(
-      byte[] slice, Option<PublicKey> externalKey) {
+      byte[] slice, Optional<PublicKey> externalKey) {
     try {
       Schema.Block data = Schema.Block.parseFrom(slice);
       return Block.deserialize(data, externalKey);
@@ -505,7 +505,7 @@ public final class Block {
     return Collections.unmodifiableList(scopes);
   }
 
-  public Option<PublicKey> getExternalKey() {
+  public Optional<PublicKey> getExternalKey() {
     return externalKey;
   }
 

--- a/src/main/java/org/eclipse/biscuit/token/Block.java
+++ b/src/main/java/org/eclipse/biscuit/token/Block.java
@@ -305,43 +305,39 @@ public final class Block {
     ArrayList<Check> checks = new ArrayList<>();
 
     for (Schema.FactV2 fact : b.getFactsV2List()) {
-      Either<Error.FormatError, Fact> res = Fact.deserializeV2(fact);
-      if (res.isLeft()) {
-        Error.FormatError e = res.getLeft();
-        return Left(e);
+      var res = Fact.deserializeV2(fact);
+      if (res.isErr()) {
+        return Left(res.getErr());
       } else {
-        facts.add(res.get());
+        facts.add(res.getOk());
       }
     }
 
     for (Schema.RuleV2 rule : b.getRulesV2List()) {
-      Either<Error.FormatError, Rule> res = Rule.deserializeV2(rule);
-      if (res.isLeft()) {
-        Error.FormatError e = res.getLeft();
-        return Left(e);
+      var res = Rule.deserializeV2(rule);
+      if (res.isErr()) {
+        return Left(res.getErr());
       } else {
-        rules.add(res.get());
+        rules.add(res.getOk());
       }
     }
 
     for (Schema.CheckV2 check : b.getChecksV2List()) {
-      Either<Error.FormatError, Check> res = Check.deserializeV2(check);
-      if (res.isLeft()) {
-        Error.FormatError e = res.getLeft();
-        return Left(e);
+      var res = Check.deserializeV2(check);
+      if (res.isErr()) {
+        return Left(res.getErr());
       } else {
-        checks.add(res.get());
+        checks.add(res.getOk());
       }
     }
 
     ArrayList<Scope> scopes = new ArrayList<>();
     for (Schema.Scope scope : b.getScopeList()) {
-      Either<Error.FormatError, Scope> res = Scope.deserialize(scope);
-      if (res.isLeft()) {
-        Error.FormatError e = res.getLeft();
-        return Left(e);
+      var res = Scope.deserialize(scope);
+      if (res.isErr()) {
+        return Left(res.getErr());
       } else {
-        scopes.add(res.get());
+        scopes.add(res.getOk());
       }
     }
 

--- a/src/main/java/org/eclipse/biscuit/token/ThirdPartyBlockRequest.java
+++ b/src/main/java/org/eclipse/biscuit/token/ThirdPartyBlockRequest.java
@@ -9,13 +9,13 @@ import biscuit.format.schema.Schema;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.vavr.control.Either;
-import io.vavr.control.Option;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SignatureException;
 import java.util.Arrays;
+import java.util.Optional;
 import org.eclipse.biscuit.crypto.BlockSignatureBuffer;
 import org.eclipse.biscuit.crypto.PublicKey;
 import org.eclipse.biscuit.crypto.Signer;
@@ -35,7 +35,7 @@ public final class ThirdPartyBlockRequest {
       throws NoSuchAlgorithmException, InvalidKeyException, SignatureException {
     SymbolTable symbolTable = new SymbolTable();
     org.eclipse.biscuit.token.Block block =
-        blockBuilder.build(symbolTable, Option.some(externalSigner.getPublicKey()));
+        blockBuilder.build(symbolTable, Optional.of(externalSigner.getPublicKey()));
 
     Either<Error.FormatError, byte[]> res = block.toBytes();
     if (res.isLeft()) {

--- a/src/main/java/org/eclipse/biscuit/token/UnverifiedBiscuit.java
+++ b/src/main/java/org/eclipse/biscuit/token/UnverifiedBiscuit.java
@@ -166,8 +166,8 @@ public class UnverifiedBiscuit {
     }
 
     var containerRes = copiedBiscuit.serializedBiscuit.append(keypair, block, Optional.empty());
-    if (containerRes.isLeft()) {
-      throw containerRes.getLeft();
+    if (containerRes.isErr()) {
+      throw containerRes.getErr();
     }
 
     SymbolTable symbols = new SymbolTable(copiedBiscuit.symbolTable);
@@ -180,7 +180,7 @@ public class UnverifiedBiscuit {
       blocks.add(b);
     }
     blocks.add(block);
-    SerializedBiscuit container = containerRes.get();
+    SerializedBiscuit container = containerRes.getOk();
 
     return new UnverifiedBiscuit(copiedBiscuit.authority, blocks, symbols, container);
   }
@@ -298,11 +298,11 @@ public class UnverifiedBiscuit {
     }
 
     var res = Block.fromBytes(blockResponse.getPayload(), Optional.of(externalKey));
-    if (res.isLeft()) {
-      throw res.getLeft();
+    if (res.isErr()) {
+      throw res.getErr();
     }
 
-    Block block = res.get();
+    Block block = res.getOk();
 
     ExternalSignature externalSignature =
         new ExternalSignature(externalKey, blockResponse.getSignature());
@@ -311,11 +311,11 @@ public class UnverifiedBiscuit {
 
     var containerRes =
         copiedBiscuit.serializedBiscuit.append(nextKeyPair, block, Optional.of(externalSignature));
-    if (containerRes.isLeft()) {
-      throw containerRes.getLeft();
+    if (containerRes.isErr()) {
+      throw containerRes.getErr();
     }
 
-    SerializedBiscuit container = containerRes.get();
+    SerializedBiscuit container = containerRes.getOk();
 
     SymbolTable symbols = new SymbolTable(copiedBiscuit.symbolTable);
 
@@ -364,8 +364,8 @@ public class UnverifiedBiscuit {
       throws Error, NoSuchAlgorithmException, SignatureException, InvalidKeyException {
     SerializedBiscuit serializedBiscuit = this.serializedBiscuit;
     var result = serializedBiscuit.verify(publicKey);
-    if (result.isLeft()) {
-      throw result.getLeft();
+    if (result.isErr()) {
+      throw result.getErr();
     }
     return Biscuit.fromSerializedBiscuit(serializedBiscuit, this.symbolTable);
   }
@@ -380,8 +380,8 @@ public class UnverifiedBiscuit {
     }
 
     var result = serializedBiscuit.verify(root.get());
-    if (result.isLeft()) {
-      throw result.getLeft();
+    if (result.isErr()) {
+      throw result.getErr();
     }
     return Biscuit.fromSerializedBiscuit(serializedBiscuit, this.symbolTable);
   }

--- a/src/main/java/org/eclipse/biscuit/token/UnverifiedBiscuit.java
+++ b/src/main/java/org/eclipse/biscuit/token/UnverifiedBiscuit.java
@@ -6,7 +6,6 @@
 package org.eclipse.biscuit.token;
 
 import biscuit.format.schema.Schema.PublicKey.Algorithm;
-import io.vavr.Tuple2;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -22,6 +21,7 @@ import org.eclipse.biscuit.crypto.KeyDelegate;
 import org.eclipse.biscuit.crypto.KeyPair;
 import org.eclipse.biscuit.crypto.PublicKey;
 import org.eclipse.biscuit.datalog.Check;
+import org.eclipse.biscuit.datalog.Pair;
 import org.eclipse.biscuit.datalog.SymbolTable;
 import org.eclipse.biscuit.error.Error;
 import org.eclipse.biscuit.token.format.ExternalSignature;
@@ -92,7 +92,7 @@ public class UnverifiedBiscuit {
    */
   private static UnverifiedBiscuit fromSerializedBiscuit(
       SerializedBiscuit ser, SymbolTable symbolTable) throws Error {
-    Tuple2<Block, ArrayList<Block>> t = ser.extractBlocks(symbolTable);
+    Pair<Block, ArrayList<Block>> t = ser.extractBlocks(symbolTable);
     Block authority = t._1;
     ArrayList<Block> blocks = t._2;
 

--- a/src/main/java/org/eclipse/biscuit/token/builder/Biscuit.java
+++ b/src/main/java/org/eclipse/biscuit/token/builder/Biscuit.java
@@ -9,11 +9,11 @@ import static org.eclipse.biscuit.token.UnverifiedBiscuit.defaultSymbolTable;
 
 import io.vavr.Tuple2;
 import io.vavr.control.Either;
-import io.vavr.control.Option;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.eclipse.biscuit.crypto.PublicKey;
 import org.eclipse.biscuit.crypto.Signer;
 import org.eclipse.biscuit.datalog.SchemaVersion;
@@ -30,7 +30,7 @@ public final class Biscuit {
   private List<Rule> rules;
   private List<Check> checks;
   private List<Scope> scopes;
-  private Option<Integer> rootKeyId;
+  private Optional<Integer> rootKeyId;
 
   public Biscuit(final SecureRandom rng, final Signer root) {
     this.rng = rng;
@@ -40,10 +40,13 @@ public final class Biscuit {
     this.rules = new ArrayList<>();
     this.checks = new ArrayList<>();
     this.scopes = new ArrayList<>();
-    this.rootKeyId = Option.none();
+    this.rootKeyId = Optional.empty();
   }
 
-  public Biscuit(final SecureRandom rng, final Signer root, Option<Integer> rootKeyId) {
+  public Biscuit(
+      final SecureRandom rng,
+      final org.eclipse.biscuit.crypto.Signer root,
+      Optional<Integer> rootKeyId) {
     this.rng = rng;
     this.root = root;
     this.context = "";
@@ -56,8 +59,8 @@ public final class Biscuit {
 
   public Biscuit(
       final SecureRandom rng,
-      final Signer root,
-      Option<Integer> rootKeyId,
+      final org.eclipse.biscuit.crypto.Signer root,
+      Optional<Integer> rootKeyId,
       org.eclipse.biscuit.token.builder.Block block) {
     this.rng = rng;
     this.root = root;
@@ -135,7 +138,7 @@ public final class Biscuit {
   }
 
   public void setRootKeyId(Integer i) {
-    this.rootKeyId = Option.some(i);
+    this.rootKeyId = Optional.of(i);
   }
 
   public org.eclipse.biscuit.token.Biscuit build() throws Error {
@@ -184,10 +187,10 @@ public final class Biscuit {
             checks,
             scopes,
             publicKeys,
-            Option.none(),
+            Optional.empty(),
             schemaVersion.version());
 
-    if (this.rootKeyId.isDefined()) {
+    if (this.rootKeyId.isPresent()) {
       return org.eclipse.biscuit.token.Biscuit.make(
           this.rng, this.root, this.rootKeyId.get(), authorityBlock);
     } else {

--- a/src/main/java/org/eclipse/biscuit/token/builder/Biscuit.java
+++ b/src/main/java/org/eclipse/biscuit/token/builder/Biscuit.java
@@ -7,8 +7,6 @@ package org.eclipse.biscuit.token.builder;
 
 import static org.eclipse.biscuit.token.UnverifiedBiscuit.defaultSymbolTable;
 
-import io.vavr.Tuple2;
-import io.vavr.control.Either;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -79,16 +77,11 @@ public final class Biscuit {
   }
 
   public Biscuit addAuthorityFact(String s) throws Error.Parser, Error.Language {
-    Either<org.eclipse.biscuit.token.builder.parser.Error, Tuple2<String, Fact>> res =
-        Parser.fact(s);
-
-    if (res.isLeft()) {
-      throw new Error.Parser(res.getLeft());
+    var res = Parser.fact(s);
+    if (res.isErr()) {
+      throw new Error.Parser(res.getErr());
     }
-
-    Tuple2<String, Fact> t = res.get();
-
-    return addAuthorityFact(t._2);
+    return addAuthorityFact(res.getOk()._2);
   }
 
   public Biscuit addAuthorityRule(Rule rule) {
@@ -97,16 +90,11 @@ public final class Biscuit {
   }
 
   public Biscuit addAuthorityRule(String s) throws Error.Parser {
-    Either<org.eclipse.biscuit.token.builder.parser.Error, Tuple2<String, Rule>> res =
-        Parser.rule(s);
-
-    if (res.isLeft()) {
-      throw new Error.Parser(res.getLeft());
+    var res = Parser.rule(s);
+    if (res.isErr()) {
+      throw new Error.Parser(res.getErr());
     }
-
-    Tuple2<String, Rule> t = res.get();
-
-    return addAuthorityRule(t._2);
+    return addAuthorityRule(res.getOk()._2);
   }
 
   public Biscuit addAuthorityCheck(Check c) {
@@ -115,16 +103,11 @@ public final class Biscuit {
   }
 
   public Biscuit addAuthorityCheck(String s) throws Error.Parser {
-    Either<org.eclipse.biscuit.token.builder.parser.Error, Tuple2<String, Check>> res =
-        Parser.check(s);
-
-    if (res.isLeft()) {
-      throw new Error.Parser(res.getLeft());
+    var res = Parser.check(s);
+    if (res.isErr()) {
+      throw new Error.Parser(res.getErr());
     }
-
-    Tuple2<String, Check> t = res.get();
-
-    return addAuthorityCheck(t._2);
+    return addAuthorityCheck(res.getOk()._2);
   }
 
   public Biscuit setContext(String context) {

--- a/src/main/java/org/eclipse/biscuit/token/builder/Block.java
+++ b/src/main/java/org/eclipse/biscuit/token/builder/Block.java
@@ -15,8 +15,6 @@ import static org.eclipse.biscuit.token.builder.Utils.str;
 import static org.eclipse.biscuit.token.builder.Utils.string;
 import static org.eclipse.biscuit.token.builder.Utils.var;
 
-import io.vavr.Tuple2;
-import io.vavr.control.Either;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -51,16 +49,11 @@ public final class Block {
   }
 
   public Block addFact(String s) throws Error.Parser {
-    Either<org.eclipse.biscuit.token.builder.parser.Error, Tuple2<String, Fact>> res =
-        Parser.fact(s);
-
-    if (res.isLeft()) {
-      throw new Error.Parser(res.getLeft());
+    var res = Parser.fact(s);
+    if (res.isErr()) {
+      throw new Error.Parser(res.getErr());
     }
-
-    Tuple2<String, Fact> t = res.get();
-
-    return addFact(t._2);
+    return addFact(res.getOk()._2);
   }
 
   public Block addRule(Rule rule) {
@@ -69,16 +62,11 @@ public final class Block {
   }
 
   public Block addRule(String s) throws Error.Parser {
-    Either<org.eclipse.biscuit.token.builder.parser.Error, Tuple2<String, Rule>> res =
-        Parser.rule(s);
-
-    if (res.isLeft()) {
-      throw new Error.Parser(res.getLeft());
+    var res = Parser.rule(s);
+    if (res.isErr()) {
+      throw new Error.Parser(res.getErr());
     }
-
-    Tuple2<String, Rule> t = res.get();
-
-    return addRule(t._2);
+    return addRule(res.getOk()._2);
   }
 
   public Block addCheck(Check check) {
@@ -87,16 +75,11 @@ public final class Block {
   }
 
   public Block addCheck(String s) throws Error.Parser {
-    Either<org.eclipse.biscuit.token.builder.parser.Error, Tuple2<String, Check>> res =
-        Parser.check(s);
-
-    if (res.isLeft()) {
-      throw new Error.Parser(res.getLeft());
+    var res = Parser.check(s);
+    if (res.isErr()) {
+      throw new Error.Parser(res.getErr());
     }
-
-    Tuple2<String, Check> t = res.get();
-
-    return addCheck(t._2);
+    return addCheck(res.getOk()._2);
   }
 
   public Block addScope(Scope scope) {

--- a/src/main/java/org/eclipse/biscuit/token/builder/Block.java
+++ b/src/main/java/org/eclipse/biscuit/token/builder/Block.java
@@ -17,13 +17,13 @@ import static org.eclipse.biscuit.token.builder.Utils.var;
 
 import io.vavr.Tuple2;
 import io.vavr.control.Either;
-import io.vavr.control.Option;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import org.eclipse.biscuit.crypto.PublicKey;
 import org.eclipse.biscuit.datalog.SchemaVersion;
 import org.eclipse.biscuit.datalog.SymbolTable;
@@ -110,20 +110,20 @@ public final class Block {
   }
 
   public org.eclipse.biscuit.token.Block build() {
-    return build(defaultSymbolTable(), Option.none());
+    return build(defaultSymbolTable(), Optional.empty());
   }
 
-  public org.eclipse.biscuit.token.Block build(final Option<PublicKey> externalKey) {
+  public org.eclipse.biscuit.token.Block build(final Optional<PublicKey> externalKey) {
     return build(defaultSymbolTable(), externalKey);
   }
 
   public org.eclipse.biscuit.token.Block build(SymbolTable symbolTable) {
-    return build(symbolTable, Option.none());
+    return build(symbolTable, Optional.empty());
   }
 
   public org.eclipse.biscuit.token.Block build(
-      SymbolTable symbolTable, final Option<PublicKey> externalKey) {
-    if (externalKey.isDefined()) {
+      SymbolTable symbolTable, final Optional<PublicKey> externalKey) {
+    if (externalKey.isPresent()) {
       symbolTable = new SymbolTable();
     }
     final int symbolStart = symbolTable.currentOffset();

--- a/src/main/java/org/eclipse/biscuit/token/builder/Rule.java
+++ b/src/main/java/org/eclipse/biscuit/token/builder/Rule.java
@@ -6,11 +6,11 @@
 package org.eclipse.biscuit.token.builder;
 
 import io.vavr.control.Either;
-import io.vavr.control.Option;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -22,7 +22,7 @@ public final class Rule implements Cloneable {
   Predicate head;
   List<Predicate> body;
   List<Expression> expressions;
-  Option<Map<String, Option<Term>>> variables;
+  Optional<Map<String, Optional<Term>>> variables;
   List<Scope> scopes;
 
   public Rule(
@@ -31,16 +31,16 @@ public final class Rule implements Cloneable {
     this.body = body;
     this.expressions = expressions;
     this.scopes = scopes;
-    Map<String, Option<Term>> variables = new HashMap<>();
+    Map<String, Optional<Term>> variables = new HashMap<>();
     for (Term t : head.terms) {
       if (t instanceof Term.Variable) {
-        variables.put(((Term.Variable) t).value, Option.none());
+        variables.put(((Term.Variable) t).value, Optional.empty());
       }
     }
     for (Predicate p : body) {
       for (Term t : p.terms) {
         if (t instanceof Term.Variable) {
-          variables.put(((Term.Variable) t).value, Option.none());
+          variables.put(((Term.Variable) t).value, Optional.empty());
         }
       }
     }
@@ -48,11 +48,11 @@ public final class Rule implements Cloneable {
       if (e instanceof Expression.Value) {
         Expression.Value ev = (Expression.Value) e;
         if (ev.value instanceof Term.Variable) {
-          variables.put(((Term.Variable) ev.value).value, Option.none());
+          variables.put(((Term.Variable) ev.value).value, Optional.empty());
         }
       }
     }
-    this.variables = Option.some(variables);
+    this.variables = Optional.of(variables);
   }
 
   @Override
@@ -68,10 +68,10 @@ public final class Rule implements Cloneable {
   }
 
   public void set(String name, Term term) throws Error.Language {
-    if (this.variables.isDefined()) {
-      Option<Option<Term>> t = Option.of(this.variables.get().get(name));
-      if (t.isDefined()) {
-        this.variables.get().put(name, Option.some(term));
+    if (this.variables.isPresent()) {
+      Optional<Optional<Term>> t = Optional.of(this.variables.get().get(name));
+      if (t.get().isPresent()) {
+        this.variables.get().put(name, Optional.of(term));
       } else {
         throw new Error.Language(new FailedCheck.LanguageError.UnknownVariable("name"));
       }
@@ -81,16 +81,16 @@ public final class Rule implements Cloneable {
   }
 
   public void applyVariables() {
-    this.variables.forEach(
+    this.variables.ifPresent(
         laVariables -> {
           this.head.terms =
               this.head.terms.stream()
                   .flatMap(
                       t -> {
                         if (t instanceof Term.Variable) {
-                          Option<Term> term =
-                              laVariables.getOrDefault(((Term.Variable) t).value, Option.none());
-                          return term.map(t2 -> Stream.of(t2)).getOrElse(Stream.of(t));
+                          Optional<Term> term =
+                              laVariables.getOrDefault(((Term.Variable) t).value, Optional.empty());
+                          return term.map(t2 -> Stream.of(t2)).orElse(Stream.of(t));
                         } else {
                           return Stream.of(t);
                         }
@@ -102,9 +102,10 @@ public final class Rule implements Cloneable {
                     .flatMap(
                         t -> {
                           if (t instanceof Term.Variable) {
-                            Option<Term> term =
-                                laVariables.getOrDefault(((Term.Variable) t).value, Option.none());
-                            return term.map(t2 -> Stream.of(t2)).getOrElse(Stream.of(t));
+                            Optional<Term> term =
+                                laVariables.getOrDefault(
+                                    ((Term.Variable) t).value, Optional.empty());
+                            return term.map(t2 -> Stream.of(t2)).orElse(Stream.of(t));
                           } else {
                             return Stream.of(t);
                           }
@@ -118,10 +119,10 @@ public final class Rule implements Cloneable {
                         if (e instanceof Expression.Value) {
                           Expression.Value ev = (Expression.Value) e;
                           if (ev.value instanceof Term.Variable) {
-                            Option<Term> t =
+                            Optional<Term> t =
                                 laVariables.getOrDefault(
-                                    ((Term.Variable) ev.value).value, Option.none());
-                            if (t.isDefined()) {
+                                    ((Term.Variable) ev.value).value, Optional.empty());
+                            if (t.isPresent()) {
                               return Stream.of(new Expression.Value(t.get()));
                             }
                           }

--- a/src/main/java/org/eclipse/biscuit/token/builder/Rule.java
+++ b/src/main/java/org/eclipse/biscuit/token/builder/Rule.java
@@ -5,7 +5,6 @@
 
 package org.eclipse.biscuit.token.builder;
 
-import io.vavr.control.Either;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -17,6 +16,7 @@ import java.util.stream.Stream;
 import org.eclipse.biscuit.datalog.SymbolTable;
 import org.eclipse.biscuit.error.Error;
 import org.eclipse.biscuit.error.FailedCheck;
+import org.eclipse.biscuit.error.Result;
 
 public final class Rule implements Cloneable {
   Predicate head;
@@ -133,7 +133,7 @@ public final class Rule implements Cloneable {
         });
   }
 
-  public Either<String, Rule> validateVariables() {
+  public Result<Rule, String> validateVariables() {
     Set<String> freeVariables =
         this.head.terms.stream()
             .flatMap(
@@ -150,7 +150,7 @@ public final class Rule implements Cloneable {
       e.gatherVariables(freeVariables);
     }
     if (freeVariables.isEmpty()) {
-      return Either.right(this);
+      return Result.ok(this);
     }
 
     for (Predicate p : this.body) {
@@ -158,13 +158,13 @@ public final class Rule implements Cloneable {
         if (term instanceof Term.Variable) {
           freeVariables.remove(((Term.Variable) term).value);
           if (freeVariables.isEmpty()) {
-            return Either.right(this);
+            return Result.ok(this);
           }
         }
       }
     }
 
-    return Either.left(
+    return Result.err(
         "rule head or expressions contains variables that are not "
             + "used in predicates of the rule's body: "
             + freeVariables.toString());

--- a/src/main/java/org/eclipse/biscuit/token/builder/parser/Error.java
+++ b/src/main/java/org/eclipse/biscuit/token/builder/parser/Error.java
@@ -5,9 +5,6 @@
 
 package org.eclipse.biscuit.token.builder.parser;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-
 public final class Error extends Exception {
   String input;
   String message;
@@ -21,13 +18,6 @@ public final class Error extends Exception {
   @Override
   public String toString() {
     return "Error{" + "input='" + input + '\'' + ", message='" + message + '\'' + '}';
-  }
-
-  public JsonElement toJson() {
-    JsonObject jo = new JsonObject();
-    jo.addProperty("input", this.input);
-    jo.addProperty("message", this.message);
-    return jo;
   }
 
   @Override

--- a/src/main/java/org/eclipse/biscuit/token/builder/parser/ExpressionParser.java
+++ b/src/main/java/org/eclipse/biscuit/token/builder/parser/ExpressionParser.java
@@ -9,14 +9,14 @@ import static org.eclipse.biscuit.token.builder.parser.Parser.space;
 import static org.eclipse.biscuit.token.builder.parser.Parser.term;
 
 import io.vavr.Tuple2;
-import io.vavr.control.Either;
+import org.eclipse.biscuit.error.Result;
 import org.eclipse.biscuit.token.builder.Expression;
 import org.eclipse.biscuit.token.builder.Term;
 
 public final class ExpressionParser {
   private ExpressionParser() {}
 
-  public static Either<Error, Tuple2<String, Expression>> parse(String s) {
+  public static Result<Tuple2<String, Expression>, Error> parse(String s) {
     return expr(space(s));
   }
 
@@ -34,36 +34,36 @@ public final class ExpressionParser {
   // This level handles the last operator in the precedence list: `||`
   // `||` is left associative, so multiple `||` expressions can be combined:
   // `a || b || c <=> (a || b) || c`
-  public static Either<Error, Tuple2<String, Expression>> expr(String s) {
-    Either<Error, Tuple2<String, Expression>> res1 = expr1(s);
-    if (res1.isLeft()) {
-      return Either.left(res1.getLeft());
+  public static Result<Tuple2<String, Expression>, Error> expr(String s) {
+    var res1 = expr1(s);
+    if (res1.isErr()) {
+      return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.get();
+    Tuple2<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
     Expression e = t1._2;
 
     while (true) {
       s = space(s);
-      if (s.length() == 0) {
+      if (s.isEmpty()) {
         break;
       }
 
-      Either<Error, Tuple2<String, Expression.Op>> res2 = binaryOp0(s);
-      if (res2.isLeft()) {
+      var res2 = binaryOp0(s);
+      if (res2.isErr()) {
         break;
       }
-      Tuple2<String, Expression.Op> t2 = res2.get();
+      Tuple2<String, Expression.Op> t2 = res2.getOk();
       s = t2._1;
 
       s = space(s);
 
-      Either<Error, Tuple2<String, Expression>> res3 = expr1(s);
-      if (res3.isLeft()) {
-        return Either.left(res3.getLeft());
+      var res3 = expr1(s);
+      if (res3.isErr()) {
+        return Result.err(res3.getErr());
       }
-      Tuple2<String, Expression> t3 = res3.get();
+      Tuple2<String, Expression> t3 = res3.getOk();
 
       s = t3._1;
       Expression e2 = t3._2;
@@ -71,42 +71,42 @@ public final class ExpressionParser {
       e = new Expression.Binary(op, e, e2);
     }
 
-    return Either.right(new Tuple2<>(s, e));
+    return Result.ok(new Tuple2<>(s, e));
   }
 
   /// This level handles `&&`
   /// `&&` is left associative, so multiple `&&` expressions can be combined:
   /// `a && b && c <=> (a && b) && c`
-  public static Either<Error, Tuple2<String, Expression>> expr1(String s) {
-    Either<Error, Tuple2<String, Expression>> res1 = expr2(s);
-    if (res1.isLeft()) {
-      return Either.left(res1.getLeft());
+  public static Result<Tuple2<String, Expression>, Error> expr1(String s) {
+    var res1 = expr2(s);
+    if (res1.isErr()) {
+      return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.get();
+    Tuple2<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
     Expression e = t1._2;
 
     while (true) {
       s = space(s);
-      if (s.length() == 0) {
+      if (s.isEmpty()) {
         break;
       }
 
-      Either<Error, Tuple2<String, Expression.Op>> res2 = binaryOp1(s);
-      if (res2.isLeft()) {
+      var res2 = binaryOp1(s);
+      if (res2.isErr()) {
         break;
       }
-      Tuple2<String, Expression.Op> t2 = res2.get();
+      Tuple2<String, Expression.Op> t2 = res2.getOk();
       s = t2._1;
 
       s = space(s);
 
-      Either<Error, Tuple2<String, Expression>> res3 = expr2(s);
-      if (res3.isLeft()) {
-        return Either.left(res3.getLeft());
+      var res3 = expr2(s);
+      if (res3.isErr()) {
+        return Result.err(res3.getErr());
       }
-      Tuple2<String, Expression> t3 = res3.get();
+      Tuple2<String, Expression> t3 = res3.getOk();
 
       s = t3._1;
       Expression e2 = t3._2;
@@ -114,37 +114,37 @@ public final class ExpressionParser {
       e = new Expression.Binary(op, e, e2);
     }
 
-    return Either.right(new Tuple2<>(s, e));
+    return Result.ok(new Tuple2<>(s, e));
   }
 
   /// This level handles comparison operators (`==`, `>`, `>=`, `<`, `<=`).
   /// Those operators are _not_ associative and require explicit grouping
   /// with parentheses.
-  public static Either<Error, Tuple2<String, Expression>> expr2(String s) {
-    Either<Error, Tuple2<String, Expression>> res1 = expr3(s);
-    if (res1.isLeft()) {
-      return Either.left(res1.getLeft());
+  public static Result<Tuple2<String, Expression>, Error> expr2(String s) {
+    var res1 = expr3(s);
+    if (res1.isErr()) {
+      return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.get();
+    Tuple2<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
 
     s = space(s);
 
-    Either<Error, Tuple2<String, Expression.Op>> res2 = binaryOp2(s);
-    if (res2.isLeft()) {
-      return Either.right(t1);
+    var res2 = binaryOp2(s);
+    if (res2.isErr()) {
+      return Result.ok(t1);
     }
-    Tuple2<String, Expression.Op> t2 = res2.get();
+    Tuple2<String, Expression.Op> t2 = res2.getOk();
     s = t2._1;
 
     s = space(s);
 
-    Either<Error, Tuple2<String, Expression>> res3 = expr3(s);
-    if (res3.isLeft()) {
-      return Either.left(res3.getLeft());
+    var res3 = expr3(s);
+    if (res3.isErr()) {
+      return Result.err(res3.getErr());
     }
-    Tuple2<String, Expression> t3 = res3.get();
+    Tuple2<String, Expression> t3 = res3.getOk();
 
     s = t3._1;
     Expression e2 = t3._2;
@@ -152,42 +152,42 @@ public final class ExpressionParser {
     Expression e = t1._2;
     e = new Expression.Binary(op, e, e2);
 
-    return Either.right(new Tuple2<>(s, e));
+    return Result.ok(new Tuple2<>(s, e));
   }
 
   /// This level handles `|`.
   /// It is left associative, so multiple expressions can be combined:
   /// `a | b | c <=> (a | b) | c`
-  public static Either<Error, Tuple2<String, Expression>> expr3(String s) {
-    Either<Error, Tuple2<String, Expression>> res1 = expr4(s);
-    if (res1.isLeft()) {
-      return Either.left(res1.getLeft());
+  public static Result<Tuple2<String, Expression>, Error> expr3(String s) {
+    var res1 = expr4(s);
+    if (res1.isErr()) {
+      return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.get();
+    Tuple2<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
     Expression e = t1._2;
 
     while (true) {
       s = space(s);
-      if (s.length() == 0) {
+      if (s.isEmpty()) {
         break;
       }
 
-      Either<Error, Tuple2<String, Expression.Op>> res2 = binaryOp3(s);
-      if (res2.isLeft()) {
+      var res2 = binaryOp3(s);
+      if (res2.isErr()) {
         break;
       }
-      Tuple2<String, Expression.Op> t2 = res2.get();
+      Tuple2<String, Expression.Op> t2 = res2.getOk();
       s = t2._1;
 
       s = space(s);
 
-      Either<Error, Tuple2<String, Expression>> res3 = expr4(s);
-      if (res3.isLeft()) {
-        return Either.left(res3.getLeft());
+      var res3 = expr4(s);
+      if (res3.isErr()) {
+        return Result.err(res3.getErr());
       }
-      Tuple2<String, Expression> t3 = res3.get();
+      Tuple2<String, Expression> t3 = res3.getOk();
 
       s = t3._1;
       Expression e2 = t3._2;
@@ -196,42 +196,42 @@ public final class ExpressionParser {
       e = new Expression.Binary(op, e, e2);
     }
 
-    return Either.right(new Tuple2<>(s, e));
+    return Result.ok(new Tuple2<>(s, e));
   }
 
   /// This level handles `^`.
   /// It is left associative, so multiple expressions can be combined:
   /// `a ^ b ^ c <=> (a ^ b) ^ c`
-  public static Either<Error, Tuple2<String, Expression>> expr4(String s) {
-    Either<Error, Tuple2<String, Expression>> res1 = expr5(s);
-    if (res1.isLeft()) {
-      return Either.left(res1.getLeft());
+  public static Result<Tuple2<String, Expression>, Error> expr4(String s) {
+    var res1 = expr5(s);
+    if (res1.isErr()) {
+      return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.get();
+    Tuple2<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
     Expression e = t1._2;
 
     while (true) {
       s = space(s);
-      if (s.length() == 0) {
+      if (s.isEmpty()) {
         break;
       }
 
-      Either<Error, Tuple2<String, Expression.Op>> res2 = binaryOp4(s);
-      if (res2.isLeft()) {
+      var res2 = binaryOp4(s);
+      if (res2.isErr()) {
         break;
       }
-      Tuple2<String, Expression.Op> t2 = res2.get();
+      Tuple2<String, Expression.Op> t2 = res2.getOk();
       s = t2._1;
 
       s = space(s);
 
-      Either<Error, Tuple2<String, Expression>> res3 = expr5(s);
-      if (res3.isLeft()) {
-        return Either.left(res3.getLeft());
+      var res3 = expr5(s);
+      if (res3.isErr()) {
+        return Result.err(res3.getErr());
       }
-      Tuple2<String, Expression> t3 = res3.get();
+      Tuple2<String, Expression> t3 = res3.getOk();
 
       s = t3._1;
       Expression e2 = t3._2;
@@ -240,42 +240,42 @@ public final class ExpressionParser {
       e = new Expression.Binary(op, e, e2);
     }
 
-    return Either.right(new Tuple2<>(s, e));
+    return Result.ok(new Tuple2<>(s, e));
   }
 
   /// This level handles `&`.
   /// It is left associative, so multiple expressions can be combined:
   /// `a & b & c <=> (a & b) & c`
-  public static Either<Error, Tuple2<String, Expression>> expr5(String s) {
-    Either<Error, Tuple2<String, Expression>> res1 = expr6(s);
-    if (res1.isLeft()) {
-      return Either.left(res1.getLeft());
+  public static Result<Tuple2<String, Expression>, Error> expr5(String s) {
+    var res1 = expr6(s);
+    if (res1.isErr()) {
+      return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.get();
+    Tuple2<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
     Expression e = t1._2;
 
     while (true) {
       s = space(s);
-      if (s.length() == 0) {
+      if (s.isEmpty()) {
         break;
       }
 
-      Either<Error, Tuple2<String, Expression.Op>> res2 = binaryOp5(s);
-      if (res2.isLeft()) {
+      var res2 = binaryOp5(s);
+      if (res2.isErr()) {
         break;
       }
-      Tuple2<String, Expression.Op> t2 = res2.get();
+      Tuple2<String, Expression.Op> t2 = res2.getOk();
       s = t2._1;
 
       s = space(s);
 
-      Either<Error, Tuple2<String, Expression>> res3 = expr6(s);
-      if (res3.isLeft()) {
-        return Either.left(res3.getLeft());
+      var res3 = expr6(s);
+      if (res3.isErr()) {
+        return Result.err(res3.getErr());
       }
-      Tuple2<String, Expression> t3 = res3.get();
+      Tuple2<String, Expression> t3 = res3.getOk();
 
       s = t3._1;
       Expression e2 = t3._2;
@@ -284,42 +284,42 @@ public final class ExpressionParser {
       e = new Expression.Binary(op, e, e2);
     }
 
-    return Either.right(new Tuple2<>(s, e));
+    return Result.ok(new Tuple2<>(s, e));
   }
 
   /// This level handles `+` and `-`.
   /// They are left associative, so multiple expressions can be combined:
   /// `a + b - c <=> (a + b) - c`
-  public static Either<Error, Tuple2<String, Expression>> expr6(String s) {
-    Either<Error, Tuple2<String, Expression>> res1 = expr7(s);
-    if (res1.isLeft()) {
-      return Either.left(res1.getLeft());
+  public static Result<Tuple2<String, Expression>, Error> expr6(String s) {
+    var res1 = expr7(s);
+    if (res1.isErr()) {
+      return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.get();
+    Tuple2<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
     Expression e = t1._2;
 
     while (true) {
       s = space(s);
-      if (s.length() == 0) {
+      if (s.isEmpty()) {
         break;
       }
 
-      Either<Error, Tuple2<String, Expression.Op>> res2 = binaryOp6(s);
-      if (res2.isLeft()) {
+      var res2 = binaryOp6(s);
+      if (res2.isErr()) {
         break;
       }
-      Tuple2<String, Expression.Op> t2 = res2.get();
+      Tuple2<String, Expression.Op> t2 = res2.getOk();
       s = t2._1;
 
       s = space(s);
 
-      Either<Error, Tuple2<String, Expression>> res3 = expr7(s);
-      if (res3.isLeft()) {
-        return Either.left(res3.getLeft());
+      var res3 = expr7(s);
+      if (res3.isErr()) {
+        return Result.err(res3.getErr());
       }
-      Tuple2<String, Expression> t3 = res3.get();
+      Tuple2<String, Expression> t3 = res3.getOk();
 
       s = t3._1;
       Expression e2 = t3._2;
@@ -328,42 +328,42 @@ public final class ExpressionParser {
       e = new Expression.Binary(op, e, e2);
     }
 
-    return Either.right(new Tuple2<>(s, e));
+    return Result.ok(new Tuple2<>(s, e));
   }
 
   /// This level handles `*` and `/`.
   /// They are left associative, so multiple expressions can be combined:
   /// `a * b / c <=> (a * b) / c`
-  public static Either<Error, Tuple2<String, Expression>> expr7(String s) {
-    Either<Error, Tuple2<String, Expression>> res1 = expr8(s);
-    if (res1.isLeft()) {
-      return Either.left(res1.getLeft());
+  public static Result<Tuple2<String, Expression>, Error> expr7(String s) {
+    var res1 = expr8(s);
+    if (res1.isErr()) {
+      return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.get();
+    Tuple2<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
     Expression e = t1._2;
 
     while (true) {
       s = space(s);
-      if (s.length() == 0) {
+      if (s.isEmpty()) {
         break;
       }
 
-      Either<Error, Tuple2<String, Expression.Op>> res2 = binaryOp7(s);
-      if (res2.isLeft()) {
+      var res2 = binaryOp7(s);
+      if (res2.isErr()) {
         break;
       }
-      Tuple2<String, Expression.Op> t2 = res2.get();
+      Tuple2<String, Expression.Op> t2 = res2.getOk();
       s = t2._1;
 
       s = space(s);
 
-      Either<Error, Tuple2<String, Expression>> res3 = expr8(s);
-      if (res3.isLeft()) {
-        return Either.left(res3.getLeft());
+      var res3 = expr8(s);
+      if (res3.isErr()) {
+        return Result.err(res3.getErr());
       }
-      Tuple2<String, Expression> t3 = res3.get();
+      Tuple2<String, Expression> t3 = res3.getOk();
 
       s = t3._1;
       Expression e2 = t3._2;
@@ -372,24 +372,24 @@ public final class ExpressionParser {
       e = new Expression.Binary(op, e, e2);
     }
 
-    return Either.right(new Tuple2<>(s, e));
+    return Result.ok(new Tuple2<>(s, e));
   }
 
   /// This level handles `!` (prefix negation)
-  public static Either<Error, Tuple2<String, Expression>> expr8(String s) {
+  public static Result<Tuple2<String, Expression>, Error> expr8(String s) {
 
     s = space(s);
 
     if (s.startsWith("!")) {
       s = space(s.substring(1));
 
-      Either<Error, Tuple2<String, Expression>> res = expr9(s);
-      if (res.isLeft()) {
-        return Either.left(res.getLeft());
+      var res = expr9(s);
+      if (res.isErr()) {
+        return Result.err(res.getErr());
       }
 
-      Tuple2<String, Expression> t = res.get();
-      return Either.right(new Tuple2<>(t._1, new Expression.Unary(Expression.Op.Negate, t._2)));
+      Tuple2<String, Expression> t = res.getOk();
+      return Result.ok(new Tuple2<>(t._1, new Expression.Unary(Expression.Op.Negate, t._2)));
     } else {
       return expr9(s);
     }
@@ -398,12 +398,12 @@ public final class ExpressionParser {
   /// This level handles methods. Methods can take either zero or one
   /// argument in addition to the expression they are called on.
   /// The name of the method decides its arity.
-  public static Either<Error, Tuple2<String, Expression>> expr9(String s) {
-    Either<Error, Tuple2<String, Expression>> res1 = exprTerm(s);
-    if (res1.isLeft()) {
-      return Either.left(res1.getLeft());
+  public static Result<Tuple2<String, Expression>, Error> expr9(String s) {
+    var res1 = exprTerm(s);
+    if (res1.isErr()) {
+      return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.get();
+    Tuple2<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
     Expression e = t1._2;
@@ -415,31 +415,31 @@ public final class ExpressionParser {
       }
 
       if (!s.startsWith(".")) {
-        return Either.right(new Tuple2<>(s, e));
+        return Result.ok(new Tuple2<>(s, e));
       }
 
       s = s.substring(1);
-      Either<Error, Tuple2<String, Expression.Op>> res2 = binaryOp8(s);
-      if (!res2.isLeft()) {
-        Tuple2<String, Expression.Op> t2 = res2.get();
+      var res2 = binaryOp8(s);
+      if (!res2.isErr()) {
+        Tuple2<String, Expression.Op> t2 = res2.getOk();
         s = space(t2._1);
 
         if (!s.startsWith("(")) {
-          return Either.left(new Error(s, "missing ("));
+          return Result.err(new Error(s, "missing ("));
         }
 
         s = space(s.substring(1));
 
-        Either<Error, Tuple2<String, Expression>> res3 = expr(s);
-        if (res3.isLeft()) {
-          return Either.left(res3.getLeft());
+        var res3 = expr(s);
+        if (res3.isErr()) {
+          return Result.err(res3.getErr());
         }
 
-        Tuple2<String, Expression> t3 = res3.get();
+        Tuple2<String, Expression> t3 = res3.getOk();
 
         s = space(t3._1);
         if (!s.startsWith(")")) {
-          return Either.left(new Error(s, "missing )"));
+          return Result.err(new Error(s, "missing )"));
         }
         s = space(s.substring(1));
         Expression e2 = t3._2;
@@ -454,204 +454,204 @@ public final class ExpressionParser {
       }
     }
 
-    return Either.right(new Tuple2<>(s, e));
+    return Result.ok(new Tuple2<>(s, e));
   }
 
-  public static Either<Error, Tuple2<String, Expression>> exprTerm(String s) {
-    Either<Error, Tuple2<String, Expression>> res1 = unaryParens(s);
-    if (res1.isRight()) {
+  public static Result<Tuple2<String, Expression>, Error> exprTerm(String s) {
+    var res1 = unaryParens(s);
+    if (res1.isOk()) {
       return res1;
     }
 
-    Either<Error, Tuple2<String, Term>> res2 = term(s);
-    if (res2.isLeft()) {
-      return Either.left(res2.getLeft());
+    var res2 = term(s);
+    if (res2.isErr()) {
+      return Result.err(res2.getErr());
     }
-    Tuple2<String, Term> t2 = res2.get();
+    Tuple2<String, Term> t2 = res2.getOk();
     Expression e = new Expression.Value(t2._2);
 
-    return Either.right(new Tuple2<>(t2._1, e));
+    return Result.ok(new Tuple2<>(t2._1, e));
   }
 
-  public static Either<Error, Tuple2<String, Expression>> unary(String s) {
+  public static Result<Tuple2<String, Expression>, Error> unary(String s) {
     s = space(s);
 
     if (s.startsWith("!")) {
       s = space(s.substring(1));
 
-      Either<Error, Tuple2<String, Expression>> res = expr(s);
-      if (res.isLeft()) {
-        return Either.left(res.getLeft());
+      var res = expr(s);
+      if (res.isErr()) {
+        return Result.err(res.getErr());
       }
 
-      Tuple2<String, Expression> t = res.get();
-      return Either.right(new Tuple2<>(t._1, new Expression.Unary(Expression.Op.Negate, t._2)));
+      Tuple2<String, Expression> t = res.getOk();
+      return Result.ok(new Tuple2<>(t._1, new Expression.Unary(Expression.Op.Negate, t._2)));
     }
 
     if (s.startsWith("(")) {
-      Either<Error, Tuple2<String, Expression>> res = unaryParens(s);
-      if (res.isLeft()) {
-        return Either.left(res.getLeft());
+      var res = unaryParens(s);
+      if (res.isErr()) {
+        return Result.err(res.getErr());
       }
 
-      Tuple2<String, Expression> t = res.get();
-      return Either.right(new Tuple2<>(t._1, t._2));
+      Tuple2<String, Expression> t = res.getOk();
+      return Result.ok(new Tuple2<>(t._1, t._2));
     }
 
     Expression e;
-    Either<Error, Tuple2<String, Term>> res = term(s);
-    if (res.isRight()) {
-      Tuple2<String, Term> t = res.get();
+    var res = term(s);
+    if (res.isOk()) {
+      Tuple2<String, Term> t = res.getOk();
       s = space(t._1);
       e = new Expression.Value(t._2);
     } else {
-      Either<Error, Tuple2<String, Expression>> res2 = unaryParens(s);
-      if (res2.isLeft()) {
-        return Either.left(res2.getLeft());
+      var res2 = unaryParens(s);
+      if (res2.isErr()) {
+        return Result.err(res2.getErr());
       }
 
-      Tuple2<String, Expression> t = res2.get();
+      Tuple2<String, Expression> t = res2.getOk();
       s = space(t._1);
       e = t._2;
     }
 
     if (s.startsWith(".length()")) {
       s = space(s.substring(9));
-      return Either.right(new Tuple2<>(s, new Expression.Unary(Expression.Op.Length, e)));
+      return Result.ok(new Tuple2<>(s, new Expression.Unary(Expression.Op.Length, e)));
     } else {
-      return Either.left(new Error(s, "unexpected token"));
+      return Result.err(new Error(s, "unexpected token"));
     }
   }
 
-  public static Either<Error, Tuple2<String, Expression>> unaryParens(String s) {
+  public static Result<Tuple2<String, Expression>, Error> unaryParens(String s) {
     if (s.startsWith("(")) {
       s = space(s.substring(1));
 
-      Either<Error, Tuple2<String, Expression>> res = expr(s);
-      if (res.isLeft()) {
-        return Either.left(res.getLeft());
+      var res = expr(s);
+      if (res.isErr()) {
+        return Result.err(res.getErr());
       }
 
-      Tuple2<String, Expression> t = res.get();
+      Tuple2<String, Expression> t = res.getOk();
 
       s = space(t._1);
       if (!s.startsWith(")")) {
-        return Either.left(new Error(s, "missing )"));
+        return Result.err(new Error(s, "missing )"));
       }
 
       s = space(s.substring(1));
-      return Either.right(new Tuple2<>(s, new Expression.Unary(Expression.Op.Parens, t._2)));
+      return Result.ok(new Tuple2<>(s, new Expression.Unary(Expression.Op.Parens, t._2)));
     } else {
-      return Either.left(new Error(s, "missing ("));
+      return Result.err(new Error(s, "missing ("));
     }
   }
 
-  public static Either<Error, Tuple2<String, Expression.Op>> binaryOp0(String s) {
+  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp0(String s) {
     if (s.startsWith("||")) {
-      return Either.right(new Tuple2<>(s.substring(2), Expression.Op.Or));
+      return Result.ok(new Tuple2<>(s.substring(2), Expression.Op.Or));
     }
 
-    return Either.left(new Error(s, "unrecognized op"));
+    return Result.err(new Error(s, "unrecognized op"));
   }
 
-  public static Either<Error, Tuple2<String, Expression.Op>> binaryOp1(String s) {
+  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp1(String s) {
     if (s.startsWith("&&")) {
-      return Either.right(new Tuple2<>(s.substring(2), Expression.Op.And));
+      return Result.ok(new Tuple2<>(s.substring(2), Expression.Op.And));
     }
 
-    return Either.left(new Error(s, "unrecognized op"));
+    return Result.err(new Error(s, "unrecognized op"));
   }
 
-  public static Either<Error, Tuple2<String, Expression.Op>> binaryOp2(String s) {
+  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp2(String s) {
     if (s.startsWith("<=")) {
-      return Either.right(new Tuple2<>(s.substring(2), Expression.Op.LessOrEqual));
+      return Result.ok(new Tuple2<>(s.substring(2), Expression.Op.LessOrEqual));
     }
     if (s.startsWith(">=")) {
-      return Either.right(new Tuple2<>(s.substring(2), Expression.Op.GreaterOrEqual));
+      return Result.ok(new Tuple2<>(s.substring(2), Expression.Op.GreaterOrEqual));
     }
     if (s.startsWith("<")) {
-      return Either.right(new Tuple2<>(s.substring(1), Expression.Op.LessThan));
+      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.LessThan));
     }
     if (s.startsWith(">")) {
-      return Either.right(new Tuple2<>(s.substring(1), Expression.Op.GreaterThan));
+      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.GreaterThan));
     }
     if (s.startsWith("==")) {
-      return Either.right(new Tuple2<>(s.substring(2), Expression.Op.Equal));
+      return Result.ok(new Tuple2<>(s.substring(2), Expression.Op.Equal));
     }
     if (s.startsWith("!=")) {
-      return Either.right(new Tuple2<>(s.substring(2), Expression.Op.NotEqual));
+      return Result.ok(new Tuple2<>(s.substring(2), Expression.Op.NotEqual));
     }
 
-    return Either.left(new Error(s, "unrecognized op"));
+    return Result.err(new Error(s, "unrecognized op"));
   }
 
-  public static Either<Error, Tuple2<String, Expression.Op>> binaryOp3(String s) {
+  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp3(String s) {
     if (s.startsWith("^")) {
-      return Either.right(new Tuple2<>(s.substring(1), Expression.Op.BitwiseXor));
+      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.BitwiseXor));
     }
 
-    return Either.left(new Error(s, "unrecognized op"));
+    return Result.err(new Error(s, "unrecognized op"));
   }
 
-  public static Either<Error, Tuple2<String, Expression.Op>> binaryOp4(String s) {
+  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp4(String s) {
     if (s.startsWith("|") && !s.startsWith("||")) {
-      return Either.right(new Tuple2<>(s.substring(1), Expression.Op.BitwiseOr));
+      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.BitwiseOr));
     }
 
-    return Either.left(new Error(s, "unrecognized op"));
+    return Result.err(new Error(s, "unrecognized op"));
   }
 
-  public static Either<Error, Tuple2<String, Expression.Op>> binaryOp5(String s) {
+  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp5(String s) {
     if (s.startsWith("&") && !s.startsWith("&&")) {
-      return Either.right(new Tuple2<>(s.substring(1), Expression.Op.BitwiseAnd));
+      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.BitwiseAnd));
     }
 
-    return Either.left(new Error(s, "unrecognized op"));
+    return Result.err(new Error(s, "unrecognized op"));
   }
 
-  public static Either<Error, Tuple2<String, Expression.Op>> binaryOp6(String s) {
+  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp6(String s) {
 
     if (s.startsWith("+")) {
-      return Either.right(new Tuple2<>(s.substring(1), Expression.Op.Add));
+      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.Add));
     }
     if (s.startsWith("-")) {
-      return Either.right(new Tuple2<>(s.substring(1), Expression.Op.Sub));
+      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.Sub));
     }
 
-    return Either.left(new Error(s, "unrecognized op"));
+    return Result.err(new Error(s, "unrecognized op"));
   }
 
-  public static Either<Error, Tuple2<String, Expression.Op>> binaryOp7(String s) {
+  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp7(String s) {
     if (s.startsWith("*")) {
-      return Either.right(new Tuple2<>(s.substring(1), Expression.Op.Mul));
+      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.Mul));
     }
     if (s.startsWith("/")) {
-      return Either.right(new Tuple2<>(s.substring(1), Expression.Op.Div));
+      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.Div));
     }
 
-    return Either.left(new Error(s, "unrecognized op"));
+    return Result.err(new Error(s, "unrecognized op"));
   }
 
-  public static Either<Error, Tuple2<String, Expression.Op>> binaryOp8(String s) {
+  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp8(String s) {
     if (s.startsWith("intersection")) {
-      return Either.right(new Tuple2<>(s.substring(12), Expression.Op.Intersection));
+      return Result.ok(new Tuple2<>(s.substring(12), Expression.Op.Intersection));
     }
     if (s.startsWith("union")) {
-      return Either.right(new Tuple2<>(s.substring(5), Expression.Op.Union));
+      return Result.ok(new Tuple2<>(s.substring(5), Expression.Op.Union));
     }
     if (s.startsWith("contains")) {
-      return Either.right(new Tuple2<>(s.substring(8), Expression.Op.Contains));
+      return Result.ok(new Tuple2<>(s.substring(8), Expression.Op.Contains));
     }
     if (s.startsWith("starts_with")) {
-      return Either.right(new Tuple2<>(s.substring(11), Expression.Op.Prefix));
+      return Result.ok(new Tuple2<>(s.substring(11), Expression.Op.Prefix));
     }
     if (s.startsWith("ends_with")) {
-      return Either.right(new Tuple2<>(s.substring(9), Expression.Op.Suffix));
+      return Result.ok(new Tuple2<>(s.substring(9), Expression.Op.Suffix));
     }
     if (s.startsWith("matches")) {
-      return Either.right(new Tuple2<>(s.substring(7), Expression.Op.Regex));
+      return Result.ok(new Tuple2<>(s.substring(7), Expression.Op.Regex));
     }
 
-    return Either.left(new Error(s, "unrecognized op"));
+    return Result.err(new Error(s, "unrecognized op"));
   }
 }

--- a/src/main/java/org/eclipse/biscuit/token/builder/parser/ExpressionParser.java
+++ b/src/main/java/org/eclipse/biscuit/token/builder/parser/ExpressionParser.java
@@ -8,7 +8,7 @@ package org.eclipse.biscuit.token.builder.parser;
 import static org.eclipse.biscuit.token.builder.parser.Parser.space;
 import static org.eclipse.biscuit.token.builder.parser.Parser.term;
 
-import io.vavr.Tuple2;
+import org.eclipse.biscuit.datalog.Pair;
 import org.eclipse.biscuit.error.Result;
 import org.eclipse.biscuit.token.builder.Expression;
 import org.eclipse.biscuit.token.builder.Term;
@@ -16,7 +16,7 @@ import org.eclipse.biscuit.token.builder.Term;
 public final class ExpressionParser {
   private ExpressionParser() {}
 
-  public static Result<Tuple2<String, Expression>, Error> parse(String s) {
+  public static Result<Pair<String, Expression>, Error> parse(String s) {
     return expr(space(s));
   }
 
@@ -34,12 +34,12 @@ public final class ExpressionParser {
   // This level handles the last operator in the precedence list: `||`
   // `||` is left associative, so multiple `||` expressions can be combined:
   // `a || b || c <=> (a || b) || c`
-  public static Result<Tuple2<String, Expression>, Error> expr(String s) {
+  public static Result<Pair<String, Expression>, Error> expr(String s) {
     var res1 = expr1(s);
     if (res1.isErr()) {
       return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.getOk();
+    Pair<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
     Expression e = t1._2;
@@ -54,7 +54,7 @@ public final class ExpressionParser {
       if (res2.isErr()) {
         break;
       }
-      Tuple2<String, Expression.Op> t2 = res2.getOk();
+      Pair<String, Expression.Op> t2 = res2.getOk();
       s = t2._1;
 
       s = space(s);
@@ -63,7 +63,7 @@ public final class ExpressionParser {
       if (res3.isErr()) {
         return Result.err(res3.getErr());
       }
-      Tuple2<String, Expression> t3 = res3.getOk();
+      Pair<String, Expression> t3 = res3.getOk();
 
       s = t3._1;
       Expression e2 = t3._2;
@@ -71,18 +71,18 @@ public final class ExpressionParser {
       e = new Expression.Binary(op, e, e2);
     }
 
-    return Result.ok(new Tuple2<>(s, e));
+    return Result.ok(new Pair<>(s, e));
   }
 
   /// This level handles `&&`
   /// `&&` is left associative, so multiple `&&` expressions can be combined:
   /// `a && b && c <=> (a && b) && c`
-  public static Result<Tuple2<String, Expression>, Error> expr1(String s) {
+  public static Result<Pair<String, Expression>, Error> expr1(String s) {
     var res1 = expr2(s);
     if (res1.isErr()) {
       return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.getOk();
+    Pair<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
     Expression e = t1._2;
@@ -97,7 +97,7 @@ public final class ExpressionParser {
       if (res2.isErr()) {
         break;
       }
-      Tuple2<String, Expression.Op> t2 = res2.getOk();
+      Pair<String, Expression.Op> t2 = res2.getOk();
       s = t2._1;
 
       s = space(s);
@@ -106,7 +106,7 @@ public final class ExpressionParser {
       if (res3.isErr()) {
         return Result.err(res3.getErr());
       }
-      Tuple2<String, Expression> t3 = res3.getOk();
+      Pair<String, Expression> t3 = res3.getOk();
 
       s = t3._1;
       Expression e2 = t3._2;
@@ -114,18 +114,18 @@ public final class ExpressionParser {
       e = new Expression.Binary(op, e, e2);
     }
 
-    return Result.ok(new Tuple2<>(s, e));
+    return Result.ok(new Pair<>(s, e));
   }
 
   /// This level handles comparison operators (`==`, `>`, `>=`, `<`, `<=`).
   /// Those operators are _not_ associative and require explicit grouping
   /// with parentheses.
-  public static Result<Tuple2<String, Expression>, Error> expr2(String s) {
+  public static Result<Pair<String, Expression>, Error> expr2(String s) {
     var res1 = expr3(s);
     if (res1.isErr()) {
       return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.getOk();
+    Pair<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
 
@@ -135,7 +135,7 @@ public final class ExpressionParser {
     if (res2.isErr()) {
       return Result.ok(t1);
     }
-    Tuple2<String, Expression.Op> t2 = res2.getOk();
+    Pair<String, Expression.Op> t2 = res2.getOk();
     s = t2._1;
 
     s = space(s);
@@ -144,7 +144,7 @@ public final class ExpressionParser {
     if (res3.isErr()) {
       return Result.err(res3.getErr());
     }
-    Tuple2<String, Expression> t3 = res3.getOk();
+    Pair<String, Expression> t3 = res3.getOk();
 
     s = t3._1;
     Expression e2 = t3._2;
@@ -152,18 +152,18 @@ public final class ExpressionParser {
     Expression e = t1._2;
     e = new Expression.Binary(op, e, e2);
 
-    return Result.ok(new Tuple2<>(s, e));
+    return Result.ok(new Pair<>(s, e));
   }
 
   /// This level handles `|`.
   /// It is left associative, so multiple expressions can be combined:
   /// `a | b | c <=> (a | b) | c`
-  public static Result<Tuple2<String, Expression>, Error> expr3(String s) {
+  public static Result<Pair<String, Expression>, Error> expr3(String s) {
     var res1 = expr4(s);
     if (res1.isErr()) {
       return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.getOk();
+    Pair<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
     Expression e = t1._2;
@@ -178,7 +178,7 @@ public final class ExpressionParser {
       if (res2.isErr()) {
         break;
       }
-      Tuple2<String, Expression.Op> t2 = res2.getOk();
+      Pair<String, Expression.Op> t2 = res2.getOk();
       s = t2._1;
 
       s = space(s);
@@ -187,7 +187,7 @@ public final class ExpressionParser {
       if (res3.isErr()) {
         return Result.err(res3.getErr());
       }
-      Tuple2<String, Expression> t3 = res3.getOk();
+      Pair<String, Expression> t3 = res3.getOk();
 
       s = t3._1;
       Expression e2 = t3._2;
@@ -196,18 +196,18 @@ public final class ExpressionParser {
       e = new Expression.Binary(op, e, e2);
     }
 
-    return Result.ok(new Tuple2<>(s, e));
+    return Result.ok(new Pair<>(s, e));
   }
 
   /// This level handles `^`.
   /// It is left associative, so multiple expressions can be combined:
   /// `a ^ b ^ c <=> (a ^ b) ^ c`
-  public static Result<Tuple2<String, Expression>, Error> expr4(String s) {
+  public static Result<Pair<String, Expression>, Error> expr4(String s) {
     var res1 = expr5(s);
     if (res1.isErr()) {
       return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.getOk();
+    Pair<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
     Expression e = t1._2;
@@ -222,7 +222,7 @@ public final class ExpressionParser {
       if (res2.isErr()) {
         break;
       }
-      Tuple2<String, Expression.Op> t2 = res2.getOk();
+      Pair<String, Expression.Op> t2 = res2.getOk();
       s = t2._1;
 
       s = space(s);
@@ -231,7 +231,7 @@ public final class ExpressionParser {
       if (res3.isErr()) {
         return Result.err(res3.getErr());
       }
-      Tuple2<String, Expression> t3 = res3.getOk();
+      Pair<String, Expression> t3 = res3.getOk();
 
       s = t3._1;
       Expression e2 = t3._2;
@@ -240,18 +240,18 @@ public final class ExpressionParser {
       e = new Expression.Binary(op, e, e2);
     }
 
-    return Result.ok(new Tuple2<>(s, e));
+    return Result.ok(new Pair<>(s, e));
   }
 
   /// This level handles `&`.
   /// It is left associative, so multiple expressions can be combined:
   /// `a & b & c <=> (a & b) & c`
-  public static Result<Tuple2<String, Expression>, Error> expr5(String s) {
+  public static Result<Pair<String, Expression>, Error> expr5(String s) {
     var res1 = expr6(s);
     if (res1.isErr()) {
       return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.getOk();
+    Pair<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
     Expression e = t1._2;
@@ -266,7 +266,7 @@ public final class ExpressionParser {
       if (res2.isErr()) {
         break;
       }
-      Tuple2<String, Expression.Op> t2 = res2.getOk();
+      Pair<String, Expression.Op> t2 = res2.getOk();
       s = t2._1;
 
       s = space(s);
@@ -275,7 +275,7 @@ public final class ExpressionParser {
       if (res3.isErr()) {
         return Result.err(res3.getErr());
       }
-      Tuple2<String, Expression> t3 = res3.getOk();
+      Pair<String, Expression> t3 = res3.getOk();
 
       s = t3._1;
       Expression e2 = t3._2;
@@ -284,18 +284,18 @@ public final class ExpressionParser {
       e = new Expression.Binary(op, e, e2);
     }
 
-    return Result.ok(new Tuple2<>(s, e));
+    return Result.ok(new Pair<>(s, e));
   }
 
   /// This level handles `+` and `-`.
   /// They are left associative, so multiple expressions can be combined:
   /// `a + b - c <=> (a + b) - c`
-  public static Result<Tuple2<String, Expression>, Error> expr6(String s) {
+  public static Result<Pair<String, Expression>, Error> expr6(String s) {
     var res1 = expr7(s);
     if (res1.isErr()) {
       return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.getOk();
+    Pair<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
     Expression e = t1._2;
@@ -310,7 +310,7 @@ public final class ExpressionParser {
       if (res2.isErr()) {
         break;
       }
-      Tuple2<String, Expression.Op> t2 = res2.getOk();
+      Pair<String, Expression.Op> t2 = res2.getOk();
       s = t2._1;
 
       s = space(s);
@@ -319,7 +319,7 @@ public final class ExpressionParser {
       if (res3.isErr()) {
         return Result.err(res3.getErr());
       }
-      Tuple2<String, Expression> t3 = res3.getOk();
+      Pair<String, Expression> t3 = res3.getOk();
 
       s = t3._1;
       Expression e2 = t3._2;
@@ -328,18 +328,18 @@ public final class ExpressionParser {
       e = new Expression.Binary(op, e, e2);
     }
 
-    return Result.ok(new Tuple2<>(s, e));
+    return Result.ok(new Pair<>(s, e));
   }
 
   /// This level handles `*` and `/`.
   /// They are left associative, so multiple expressions can be combined:
   /// `a * b / c <=> (a * b) / c`
-  public static Result<Tuple2<String, Expression>, Error> expr7(String s) {
+  public static Result<Pair<String, Expression>, Error> expr7(String s) {
     var res1 = expr8(s);
     if (res1.isErr()) {
       return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.getOk();
+    Pair<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
     Expression e = t1._2;
@@ -354,7 +354,7 @@ public final class ExpressionParser {
       if (res2.isErr()) {
         break;
       }
-      Tuple2<String, Expression.Op> t2 = res2.getOk();
+      Pair<String, Expression.Op> t2 = res2.getOk();
       s = t2._1;
 
       s = space(s);
@@ -363,7 +363,7 @@ public final class ExpressionParser {
       if (res3.isErr()) {
         return Result.err(res3.getErr());
       }
-      Tuple2<String, Expression> t3 = res3.getOk();
+      Pair<String, Expression> t3 = res3.getOk();
 
       s = t3._1;
       Expression e2 = t3._2;
@@ -372,11 +372,11 @@ public final class ExpressionParser {
       e = new Expression.Binary(op, e, e2);
     }
 
-    return Result.ok(new Tuple2<>(s, e));
+    return Result.ok(new Pair<>(s, e));
   }
 
   /// This level handles `!` (prefix negation)
-  public static Result<Tuple2<String, Expression>, Error> expr8(String s) {
+  public static Result<Pair<String, Expression>, Error> expr8(String s) {
 
     s = space(s);
 
@@ -388,8 +388,8 @@ public final class ExpressionParser {
         return Result.err(res.getErr());
       }
 
-      Tuple2<String, Expression> t = res.getOk();
-      return Result.ok(new Tuple2<>(t._1, new Expression.Unary(Expression.Op.Negate, t._2)));
+      Pair<String, Expression> t = res.getOk();
+      return Result.ok(new Pair<>(t._1, new Expression.Unary(Expression.Op.Negate, t._2)));
     } else {
       return expr9(s);
     }
@@ -398,12 +398,12 @@ public final class ExpressionParser {
   /// This level handles methods. Methods can take either zero or one
   /// argument in addition to the expression they are called on.
   /// The name of the method decides its arity.
-  public static Result<Tuple2<String, Expression>, Error> expr9(String s) {
+  public static Result<Pair<String, Expression>, Error> expr9(String s) {
     var res1 = exprTerm(s);
     if (res1.isErr()) {
       return Result.err(res1.getErr());
     }
-    Tuple2<String, Expression> t1 = res1.getOk();
+    Pair<String, Expression> t1 = res1.getOk();
 
     s = t1._1;
     Expression e = t1._2;
@@ -415,13 +415,13 @@ public final class ExpressionParser {
       }
 
       if (!s.startsWith(".")) {
-        return Result.ok(new Tuple2<>(s, e));
+        return Result.ok(new Pair<>(s, e));
       }
 
       s = s.substring(1);
       var res2 = binaryOp8(s);
       if (!res2.isErr()) {
-        Tuple2<String, Expression.Op> t2 = res2.getOk();
+        Pair<String, Expression.Op> t2 = res2.getOk();
         s = space(t2._1);
 
         if (!s.startsWith("(")) {
@@ -435,7 +435,7 @@ public final class ExpressionParser {
           return Result.err(res3.getErr());
         }
 
-        Tuple2<String, Expression> t3 = res3.getOk();
+        Pair<String, Expression> t3 = res3.getOk();
 
         s = space(t3._1);
         if (!s.startsWith(")")) {
@@ -454,10 +454,10 @@ public final class ExpressionParser {
       }
     }
 
-    return Result.ok(new Tuple2<>(s, e));
+    return Result.ok(new Pair<>(s, e));
   }
 
-  public static Result<Tuple2<String, Expression>, Error> exprTerm(String s) {
+  public static Result<Pair<String, Expression>, Error> exprTerm(String s) {
     var res1 = unaryParens(s);
     if (res1.isOk()) {
       return res1;
@@ -467,13 +467,13 @@ public final class ExpressionParser {
     if (res2.isErr()) {
       return Result.err(res2.getErr());
     }
-    Tuple2<String, Term> t2 = res2.getOk();
+    Pair<String, Term> t2 = res2.getOk();
     Expression e = new Expression.Value(t2._2);
 
-    return Result.ok(new Tuple2<>(t2._1, e));
+    return Result.ok(new Pair<>(t2._1, e));
   }
 
-  public static Result<Tuple2<String, Expression>, Error> unary(String s) {
+  public static Result<Pair<String, Expression>, Error> unary(String s) {
     s = space(s);
 
     if (s.startsWith("!")) {
@@ -484,8 +484,8 @@ public final class ExpressionParser {
         return Result.err(res.getErr());
       }
 
-      Tuple2<String, Expression> t = res.getOk();
-      return Result.ok(new Tuple2<>(t._1, new Expression.Unary(Expression.Op.Negate, t._2)));
+      Pair<String, Expression> t = res.getOk();
+      return Result.ok(new Pair<>(t._1, new Expression.Unary(Expression.Op.Negate, t._2)));
     }
 
     if (s.startsWith("(")) {
@@ -494,14 +494,14 @@ public final class ExpressionParser {
         return Result.err(res.getErr());
       }
 
-      Tuple2<String, Expression> t = res.getOk();
-      return Result.ok(new Tuple2<>(t._1, t._2));
+      Pair<String, Expression> t = res.getOk();
+      return Result.ok(new Pair<>(t._1, t._2));
     }
 
     Expression e;
     var res = term(s);
     if (res.isOk()) {
-      Tuple2<String, Term> t = res.getOk();
+      Pair<String, Term> t = res.getOk();
       s = space(t._1);
       e = new Expression.Value(t._2);
     } else {
@@ -510,20 +510,20 @@ public final class ExpressionParser {
         return Result.err(res2.getErr());
       }
 
-      Tuple2<String, Expression> t = res2.getOk();
+      Pair<String, Expression> t = res2.getOk();
       s = space(t._1);
       e = t._2;
     }
 
     if (s.startsWith(".length()")) {
       s = space(s.substring(9));
-      return Result.ok(new Tuple2<>(s, new Expression.Unary(Expression.Op.Length, e)));
+      return Result.ok(new Pair<>(s, new Expression.Unary(Expression.Op.Length, e)));
     } else {
       return Result.err(new Error(s, "unexpected token"));
     }
   }
 
-  public static Result<Tuple2<String, Expression>, Error> unaryParens(String s) {
+  public static Result<Pair<String, Expression>, Error> unaryParens(String s) {
     if (s.startsWith("(")) {
       s = space(s.substring(1));
 
@@ -532,7 +532,7 @@ public final class ExpressionParser {
         return Result.err(res.getErr());
       }
 
-      Tuple2<String, Expression> t = res.getOk();
+      Pair<String, Expression> t = res.getOk();
 
       s = space(t._1);
       if (!s.startsWith(")")) {
@@ -540,116 +540,116 @@ public final class ExpressionParser {
       }
 
       s = space(s.substring(1));
-      return Result.ok(new Tuple2<>(s, new Expression.Unary(Expression.Op.Parens, t._2)));
+      return Result.ok(new Pair<>(s, new Expression.Unary(Expression.Op.Parens, t._2)));
     } else {
       return Result.err(new Error(s, "missing ("));
     }
   }
 
-  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp0(String s) {
+  public static Result<Pair<String, Expression.Op>, Error> binaryOp0(String s) {
     if (s.startsWith("||")) {
-      return Result.ok(new Tuple2<>(s.substring(2), Expression.Op.Or));
+      return Result.ok(new Pair<>(s.substring(2), Expression.Op.Or));
     }
 
     return Result.err(new Error(s, "unrecognized op"));
   }
 
-  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp1(String s) {
+  public static Result<Pair<String, Expression.Op>, Error> binaryOp1(String s) {
     if (s.startsWith("&&")) {
-      return Result.ok(new Tuple2<>(s.substring(2), Expression.Op.And));
+      return Result.ok(new Pair<>(s.substring(2), Expression.Op.And));
     }
 
     return Result.err(new Error(s, "unrecognized op"));
   }
 
-  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp2(String s) {
+  public static Result<Pair<String, Expression.Op>, Error> binaryOp2(String s) {
     if (s.startsWith("<=")) {
-      return Result.ok(new Tuple2<>(s.substring(2), Expression.Op.LessOrEqual));
+      return Result.ok(new Pair<>(s.substring(2), Expression.Op.LessOrEqual));
     }
     if (s.startsWith(">=")) {
-      return Result.ok(new Tuple2<>(s.substring(2), Expression.Op.GreaterOrEqual));
+      return Result.ok(new Pair<>(s.substring(2), Expression.Op.GreaterOrEqual));
     }
     if (s.startsWith("<")) {
-      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.LessThan));
+      return Result.ok(new Pair<>(s.substring(1), Expression.Op.LessThan));
     }
     if (s.startsWith(">")) {
-      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.GreaterThan));
+      return Result.ok(new Pair<>(s.substring(1), Expression.Op.GreaterThan));
     }
     if (s.startsWith("==")) {
-      return Result.ok(new Tuple2<>(s.substring(2), Expression.Op.Equal));
+      return Result.ok(new Pair<>(s.substring(2), Expression.Op.Equal));
     }
     if (s.startsWith("!=")) {
-      return Result.ok(new Tuple2<>(s.substring(2), Expression.Op.NotEqual));
+      return Result.ok(new Pair<>(s.substring(2), Expression.Op.NotEqual));
     }
 
     return Result.err(new Error(s, "unrecognized op"));
   }
 
-  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp3(String s) {
+  public static Result<Pair<String, Expression.Op>, Error> binaryOp3(String s) {
     if (s.startsWith("^")) {
-      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.BitwiseXor));
+      return Result.ok(new Pair<>(s.substring(1), Expression.Op.BitwiseXor));
     }
 
     return Result.err(new Error(s, "unrecognized op"));
   }
 
-  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp4(String s) {
+  public static Result<Pair<String, Expression.Op>, Error> binaryOp4(String s) {
     if (s.startsWith("|") && !s.startsWith("||")) {
-      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.BitwiseOr));
+      return Result.ok(new Pair<>(s.substring(1), Expression.Op.BitwiseOr));
     }
 
     return Result.err(new Error(s, "unrecognized op"));
   }
 
-  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp5(String s) {
+  public static Result<Pair<String, Expression.Op>, Error> binaryOp5(String s) {
     if (s.startsWith("&") && !s.startsWith("&&")) {
-      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.BitwiseAnd));
+      return Result.ok(new Pair<>(s.substring(1), Expression.Op.BitwiseAnd));
     }
 
     return Result.err(new Error(s, "unrecognized op"));
   }
 
-  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp6(String s) {
+  public static Result<Pair<String, Expression.Op>, Error> binaryOp6(String s) {
 
     if (s.startsWith("+")) {
-      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.Add));
+      return Result.ok(new Pair<>(s.substring(1), Expression.Op.Add));
     }
     if (s.startsWith("-")) {
-      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.Sub));
+      return Result.ok(new Pair<>(s.substring(1), Expression.Op.Sub));
     }
 
     return Result.err(new Error(s, "unrecognized op"));
   }
 
-  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp7(String s) {
+  public static Result<Pair<String, Expression.Op>, Error> binaryOp7(String s) {
     if (s.startsWith("*")) {
-      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.Mul));
+      return Result.ok(new Pair<>(s.substring(1), Expression.Op.Mul));
     }
     if (s.startsWith("/")) {
-      return Result.ok(new Tuple2<>(s.substring(1), Expression.Op.Div));
+      return Result.ok(new Pair<>(s.substring(1), Expression.Op.Div));
     }
 
     return Result.err(new Error(s, "unrecognized op"));
   }
 
-  public static Result<Tuple2<String, Expression.Op>, Error> binaryOp8(String s) {
+  public static Result<Pair<String, Expression.Op>, Error> binaryOp8(String s) {
     if (s.startsWith("intersection")) {
-      return Result.ok(new Tuple2<>(s.substring(12), Expression.Op.Intersection));
+      return Result.ok(new Pair<>(s.substring(12), Expression.Op.Intersection));
     }
     if (s.startsWith("union")) {
-      return Result.ok(new Tuple2<>(s.substring(5), Expression.Op.Union));
+      return Result.ok(new Pair<>(s.substring(5), Expression.Op.Union));
     }
     if (s.startsWith("contains")) {
-      return Result.ok(new Tuple2<>(s.substring(8), Expression.Op.Contains));
+      return Result.ok(new Pair<>(s.substring(8), Expression.Op.Contains));
     }
     if (s.startsWith("starts_with")) {
-      return Result.ok(new Tuple2<>(s.substring(11), Expression.Op.Prefix));
+      return Result.ok(new Pair<>(s.substring(11), Expression.Op.Prefix));
     }
     if (s.startsWith("ends_with")) {
-      return Result.ok(new Tuple2<>(s.substring(9), Expression.Op.Suffix));
+      return Result.ok(new Pair<>(s.substring(9), Expression.Op.Suffix));
     }
     if (s.startsWith("matches")) {
-      return Result.ok(new Tuple2<>(s.substring(7), Expression.Op.Regex));
+      return Result.ok(new Pair<>(s.substring(7), Expression.Op.Regex));
     }
 
     return Result.err(new Error(s, "unrecognized op"));

--- a/src/main/java/org/eclipse/biscuit/token/builder/parser/Parser.java
+++ b/src/main/java/org/eclipse/biscuit/token/builder/parser/Parser.java
@@ -7,7 +7,6 @@ package org.eclipse.biscuit.token.builder.parser;
 
 import biscuit.format.schema.Schema;
 import io.vavr.Tuple2;
-import io.vavr.collection.Stream;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -46,12 +45,13 @@ public final class Parser {
     public final List<Expression> expressions;
     public final List<Scope> scopes;
 
-      public RuleBody(String head, List<Predicate> predicates, List<Expression> expressions, List<Scope> scopes) {
-          this.head = head;
-          this.predicates = predicates;
-          this.expressions = expressions;
-          this.scopes = scopes;
-      }
+    public RuleBody(
+        String head, List<Predicate> predicates, List<Expression> expressions, List<Scope> scopes) {
+      this.head = head;
+      this.predicates = predicates;
+      this.expressions = expressions;
+      this.scopes = scopes;
+    }
   }
 
   /**
@@ -75,76 +75,72 @@ public final class Parser {
     s = removeCommentsAndWhitespaces(s);
     String[] codeLines = s.split(";");
 
-    Stream.of(codeLines)
-        .zipWithIndex()
-        .forEach(
-            indexedLine -> {
-              String code = indexedLine._1.strip();
+    for (int i = 0; i < codeLines.length; ++i) {
+      String code = codeLines[i];
 
-              if (!code.isEmpty()) {
-                List<Error> lineErrors = new ArrayList<>();
+      if (!code.isEmpty()) {
+        List<Error> lineErrors = new ArrayList<>();
 
-                boolean parsed;
-                var ruleResult = rule(code);
-                if (ruleResult.isOk()) {
-                  components.rules.add(ruleResult.getOk()._2);
-                  parsed = true;
-                } else {
-                  lineErrors.add(ruleResult.getErr());
-                  parsed = false;
-                }
+        boolean parsed;
+        var ruleResult = rule(code);
+        if (ruleResult.isOk()) {
+          components.rules.add(ruleResult.getOk()._2);
+          parsed = true;
+        } else {
+          lineErrors.add(ruleResult.getErr());
+          parsed = false;
+        }
 
-                if (!parsed) {
-                  var factResult = fact(code);
-                  if (factResult.isOk()) {
-                    components.facts.add(factResult.getOk()._2);
-                    parsed = true;
-                  } else {
-                    lineErrors.add(factResult.getErr());
-                    parsed = false;
-                  }
-                }
+        if (!parsed) {
+          var factResult = fact(code);
+          if (factResult.isOk()) {
+            components.facts.add(factResult.getOk()._2);
+            parsed = true;
+          } else {
+            lineErrors.add(factResult.getErr());
+            parsed = false;
+          }
+        }
 
-                if (!parsed) {
-                  var checkResult = check(code);
-                  if (checkResult.isOk()) {
-                    components.checks.add(checkResult.getOk()._2);
-                    parsed = true;
-                  } else {
-                    lineErrors.add(checkResult.getErr());
-                    parsed = false;
-                  }
-                }
+        if (!parsed) {
+          var checkResult = check(code);
+          if (checkResult.isOk()) {
+            components.checks.add(checkResult.getOk()._2);
+            parsed = true;
+          } else {
+            lineErrors.add(checkResult.getErr());
+            parsed = false;
+          }
+        }
 
-                if (!parsed) {
-                  var scopeResult = scope(code);
-                  if (scopeResult.isOk()) {
-                    components.scopes.add(scopeResult.getOk()._2);
-                    parsed = true;
-                  } else {
-                    lineErrors.add(scopeResult.getErr());
-                    parsed = false;
-                  }
-                }
+        if (!parsed) {
+          var scopeResult = scope(code);
+          if (scopeResult.isOk()) {
+            components.scopes.add(scopeResult.getOk()._2);
+            parsed = true;
+          } else {
+            lineErrors.add(scopeResult.getErr());
+            parsed = false;
+          }
+        }
 
-                if (!parsed) {
-                  var policyResult = policy(code);
-                  if (policyResult.isOk()) {
-                    components.policies.add(policyResult.getOk()._2);
-                    parsed = true;
-                  } else {
-                    lineErrors.add(policyResult.getErr());
-                    parsed = false;
-                  }
-                }
+        if (!parsed) {
+          var policyResult = policy(code);
+          if (policyResult.isOk()) {
+            components.policies.add(policyResult.getOk()._2);
+            parsed = true;
+          } else {
+            lineErrors.add(policyResult.getErr());
+            parsed = false;
+          }
+        }
 
-                if (!parsed) {
-                  lineErrors.forEach(System.out::println);
-                  int lineNumber = indexedLine._2;
-                  errors.put(lineNumber, lineErrors);
-                }
-              }
-            });
+        if (!parsed) {
+          lineErrors.forEach(System.out::println);
+          errors.put(i, lineErrors);
+        }
+      }
+    }
 
     if (!errors.isEmpty()) {
       return Result.err(errors);
@@ -233,7 +229,8 @@ public final class Parser {
     RuleBody body = bodyRes.getOk();
 
     if (!body.head.isEmpty()) {
-      return Result.err(new Error(s, "the string was not entirely parsed, remaining: " + body.head));
+      return Result.err(
+          new Error(s, "the string was not entirely parsed, remaining: " + body.head));
     }
 
     Predicate head = t0._2;
@@ -313,7 +310,12 @@ public final class Parser {
 
     s = body.head;
     // FIXME: parse scopes
-    queries.add(new Rule(new Predicate("query", new ArrayList<>()), body.predicates, body.expressions, body.scopes));
+    queries.add(
+        new Rule(
+            new Predicate("query", new ArrayList<>()),
+            body.predicates,
+            body.expressions,
+            body.scopes));
 
     int i = 0;
     while (true) {
@@ -337,7 +339,11 @@ public final class Parser {
 
       s = body2.head;
       queries.add(
-          new Rule(new Predicate("query", new ArrayList<>()), body2.predicates, body2.expressions, body2.scopes));
+          new Rule(
+              new Predicate("query", new ArrayList<>()),
+              body2.predicates,
+              body2.expressions,
+              body2.scopes));
     }
 
     return Result.ok(new Tuple2<>(s, queries));
@@ -377,7 +383,7 @@ public final class Parser {
 
     var res = scopes(s);
     if (res.isErr()) {
-      return Result.ok(new RuleBody(s, predicates,  expressions, new ArrayList<>()));
+      return Result.ok(new RuleBody(s, predicates, expressions, new ArrayList<>()));
     } else {
       Tuple2<String, List<Scope>> t = res.getOk();
       return Result.ok(new RuleBody(t._1, predicates, expressions, t._2));

--- a/src/main/java/org/eclipse/biscuit/token/builder/parser/Parser.java
+++ b/src/main/java/org/eclipse/biscuit/token/builder/parser/Parser.java
@@ -6,7 +6,6 @@
 package org.eclipse.biscuit.token.builder.parser;
 
 import biscuit.format.schema.Schema;
-import io.vavr.Tuple2;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -16,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import org.eclipse.biscuit.crypto.PublicKey;
+import org.eclipse.biscuit.datalog.Pair;
 import org.eclipse.biscuit.error.Result;
 import org.eclipse.biscuit.token.Policy;
 import org.eclipse.biscuit.token.builder.Block;
@@ -189,28 +189,28 @@ public final class Parser {
     return Result.ok(blockBuilder);
   }
 
-  public static Result<Tuple2<String, Fact>, Error> fact(String s) {
+  public static Result<Pair<String, Fact>, Error> fact(String s) {
     var res = factPredicate(s);
     if (res.isErr()) {
       return Result.err(res.getErr());
     } else {
-      Tuple2<String, Predicate> t = res.getOk();
+      Pair<String, Predicate> t = res.getOk();
 
       if (!t._1.isEmpty()) {
         return Result.err(new Error(s, "the string was not entirely parsed, remaining: " + t._1));
       }
 
-      return Result.ok(new Tuple2<>(t._1, new Fact(t._2)));
+      return Result.ok(new Pair<>(t._1, new Fact(t._2)));
     }
   }
 
-  public static Result<Tuple2<String, Rule>, Error> rule(String s) {
+  public static Result<Pair<String, Rule>, Error> rule(String s) {
     var res0 = predicate(s);
     if (res0.isErr()) {
       return Result.err(res0.getErr());
     }
 
-    Tuple2<String, Predicate> t0 = res0.getOk();
+    Pair<String, Predicate> t0 = res0.getOk();
     s = t0._1;
 
     s = space(s);
@@ -240,10 +240,10 @@ public final class Parser {
       return Result.err(new Error(s, valid.getErr()));
     }
 
-    return Result.ok(new Tuple2<>(body.head, rule));
+    return Result.ok(new Pair<>(body.head, rule));
   }
 
-  public static Result<Tuple2<String, Check>, Error> check(String s) {
+  public static Result<Pair<String, Check>, Error> check(String s) {
     org.eclipse.biscuit.datalog.Check.Kind kind;
 
     if (s.startsWith("check if")) {
@@ -261,16 +261,16 @@ public final class Parser {
       return Result.err(bodyRes.getErr());
     }
 
-    Tuple2<String, List<Rule>> t = bodyRes.getOk();
+    Pair<String, List<Rule>> t = bodyRes.getOk();
 
     if (!t._1.isEmpty()) {
       return Result.err(new Error(s, "the string was not entirely parsed, remaining: " + t._1));
     }
 
-    return Result.ok(new Tuple2<>(t._1, new Check(kind, t._2)));
+    return Result.ok(new Pair<>(t._1, new Check(kind, t._2)));
   }
 
-  public static Result<Tuple2<String, Policy>, Error> policy(String s) {
+  public static Result<Pair<String, Policy>, Error> policy(String s) {
     Policy.Kind p = Policy.Kind.ALLOW;
 
     String allow = "allow if";
@@ -290,16 +290,16 @@ public final class Parser {
       return Result.err(bodyRes.getErr());
     }
 
-    Tuple2<String, List<Rule>> t = bodyRes.getOk();
+    Pair<String, List<Rule>> t = bodyRes.getOk();
 
     if (!t._1.isEmpty()) {
       return Result.err(new Error(s, "the string was not entirely parsed, remaining: " + t._1));
     }
 
-    return Result.ok(new Tuple2<>(t._1, new Policy(t._2, p)));
+    return Result.ok(new Pair<>(t._1, new Policy(t._2, p)));
   }
 
-  public static Result<Tuple2<String, List<Rule>>, Error> checkBody(String s) {
+  public static Result<Pair<String, List<Rule>>, Error> checkBody(String s) {
     List<Rule> queries = new ArrayList<>();
     var bodyRes = ruleBody(s);
     if (bodyRes.isErr()) {
@@ -346,7 +346,7 @@ public final class Parser {
               body2.scopes));
     }
 
-    return Result.ok(new Tuple2<>(s, queries));
+    return Result.ok(new Pair<>(s, queries));
   }
 
   public static Result<RuleBody, Error> ruleBody(String s) {
@@ -358,13 +358,13 @@ public final class Parser {
 
       var res = predicate(s);
       if (res.isOk()) {
-        Tuple2<String, Predicate> t = res.getOk();
+        Pair<String, Predicate> t = res.getOk();
         s = t._1;
         predicates.add(t._2);
       } else {
         var res2 = expression(s);
         if (res2.isOk()) {
-          Tuple2<String, Expression> t2 = res2.getOk();
+          Pair<String, Expression> t2 = res2.getOk();
           s = t2._1;
           expressions.add(t2._2);
         } else {
@@ -385,13 +385,13 @@ public final class Parser {
     if (res.isErr()) {
       return Result.ok(new RuleBody(s, predicates, expressions, new ArrayList<>()));
     } else {
-      Tuple2<String, List<Scope>> t = res.getOk();
+      Pair<String, List<Scope>> t = res.getOk();
       return Result.ok(new RuleBody(t._1, predicates, expressions, t._2));
     }
   }
 
-  public static Result<Tuple2<String, Predicate>, Error> predicate(String s) {
-    Tuple2<String, String> tn =
+  public static Result<Pair<String, Predicate>, Error> predicate(String s) {
+    Pair<String, String> tn =
         takewhile(
             s, (c) -> Character.isAlphabetic(c) || Character.isDigit(c) || c == '_' || c == ':');
     String name = tn._1;
@@ -413,7 +413,7 @@ public final class Parser {
         break;
       }
 
-      Tuple2<String, Term> t = res.getOk();
+      Pair<String, Term> t = res.getOk();
       s = t._1;
       terms.add(t._2);
 
@@ -432,10 +432,10 @@ public final class Parser {
     }
     String remaining = s.substring(1);
 
-    return Result.ok(new Tuple2<String, Predicate>(remaining, new Predicate(name, terms)));
+    return Result.ok(new Pair<String, Predicate>(remaining, new Predicate(name, terms)));
   }
 
-  public static Result<Tuple2<String, List<Scope>>, Error> scopes(String s) {
+  public static Result<Pair<String, List<Scope>>, Error> scopes(String s) {
     if (!s.startsWith("trusting")) {
       return Result.err(new Error(s, "missing scopes prefix"));
     }
@@ -452,7 +452,7 @@ public final class Parser {
         break;
       }
 
-      Tuple2<String, Scope> t = res.getOk();
+      Pair<String, Scope> t = res.getOk();
       s = t._1;
       scopes.add(t._2);
 
@@ -465,18 +465,18 @@ public final class Parser {
       }
     }
 
-    return Result.ok(new Tuple2<>(s, scopes));
+    return Result.ok(new Pair<>(s, scopes));
   }
 
-  public static Result<Tuple2<String, Scope>, Error> scope(String s) {
+  public static Result<Pair<String, Scope>, Error> scope(String s) {
     if (s.startsWith("authority")) {
       s = s.substring("authority".length());
-      return Result.ok(new Tuple2<>(s, Scope.authority()));
+      return Result.ok(new Pair<>(s, Scope.authority()));
     }
 
     if (s.startsWith("previous")) {
       s = s.substring("previous".length());
-      return Result.ok(new Tuple2<>(s, Scope.previous()));
+      return Result.ok(new Pair<>(s, Scope.previous()));
     }
 
     if (!s.isEmpty() && s.charAt(0) == '{') {
@@ -485,9 +485,9 @@ public final class Parser {
       if (res.isErr()) {
         return Result.err(new Error(s, "unrecognized parameter"));
       }
-      Tuple2<String, String> t = res.getOk();
+      Pair<String, String> t = res.getOk();
       if (!s.isEmpty() && s.charAt(0) == '}') {
-        return Result.ok(new Tuple2<>(t._1, Scope.parameter(t._2)));
+        return Result.ok(new Pair<>(t._1, Scope.parameter(t._2)));
       } else {
         return Result.err(new Error(s, "unrecognized parameter end"));
       }
@@ -497,11 +497,11 @@ public final class Parser {
     if (res2.isErr()) {
       return Result.err(new Error(s, "unrecognized public key"));
     }
-    Tuple2<String, PublicKey> t = res2.getOk();
-    return Result.ok(new Tuple2<>(t._1, Scope.publicKey(t._2)));
+    Pair<String, PublicKey> t = res2.getOk();
+    return Result.ok(new Pair<>(t._1, Scope.publicKey(t._2)));
   }
 
-  public static Result<Tuple2<String, PublicKey>, Error> publicKey(String s) {
+  public static Result<Pair<String, PublicKey>, Error> publicKey(String s) {
     Schema.PublicKey.Algorithm algorithm;
     if (s.startsWith("ed25519/")) {
       s = s.substring("ed25519/".length());
@@ -520,11 +520,11 @@ public final class Parser {
     } catch (org.eclipse.biscuit.error.Error.FormatError e) {
       return Result.err(new Error(s, e.getMessage()));
     }
-    return Result.ok(new Tuple2<>(t._1, publicKey));
+    return Result.ok(new Pair<>(t._1, publicKey));
   }
 
-  public static Result<Tuple2<String, Predicate>, Error> factPredicate(String s) {
-    Tuple2<String, String> tn =
+  public static Result<Pair<String, Predicate>, Error> factPredicate(String s) {
+    Pair<String, String> tn =
         takewhile(
             s, (c) -> Character.isAlphabetic(c) || Character.isDigit(c) || c == '_' || c == ':');
     String name = tn._1;
@@ -546,7 +546,7 @@ public final class Parser {
         break;
       }
 
-      Tuple2<String, Term> t = res.getOk();
+      Pair<String, Term> t = res.getOk();
       s = t._1;
       terms.add(t._2);
 
@@ -565,108 +565,108 @@ public final class Parser {
     }
     String remaining = s.substring(1);
 
-    return Result.ok(new Tuple2<String, Predicate>(remaining, new Predicate(name, terms)));
+    return Result.ok(new Pair<String, Predicate>(remaining, new Predicate(name, terms)));
   }
 
-  public static Result<Tuple2<String, String>, Error> name(String s) {
-    Tuple2<String, String> t = takewhile(s, (c) -> Character.isAlphabetic(c) || c == '_');
+  public static Result<Pair<String, String>, Error> name(String s) {
+    Pair<String, String> t = takewhile(s, (c) -> Character.isAlphabetic(c) || c == '_');
     String name = t._1;
     String remaining = t._2;
 
-    return Result.ok(new Tuple2<String, String>(remaining, name));
+    return Result.ok(new Pair<String, String>(remaining, name));
   }
 
-  public static Result<Tuple2<String, Term>, Error> term(String s) {
+  public static Result<Pair<String, Term>, Error> term(String s) {
     var res5 = variable(s);
     if (res5.isOk()) {
-      Tuple2<String, Term.Variable> t = res5.getOk();
-      return Result.ok(new Tuple2<>(t._1, t._2));
+      Pair<String, Term.Variable> t = res5.getOk();
+      return Result.ok(new Pair<>(t._1, t._2));
     }
 
     var res2 = string(s);
     if (res2.isOk()) {
-      Tuple2<String, Term.Str> t = res2.getOk();
-      return Result.ok(new Tuple2<>(t._1, t._2));
+      Pair<String, Term.Str> t = res2.getOk();
+      return Result.ok(new Pair<>(t._1, t._2));
     }
 
     var res7 = set(s);
     if (res7.isOk()) {
-      Tuple2<String, Term.Set> t = res7.getOk();
-      return Result.ok(new Tuple2<>(t._1, t._2));
+      Pair<String, Term.Set> t = res7.getOk();
+      return Result.ok(new Pair<>(t._1, t._2));
     }
 
     var res6 = bool(s);
     if (res6.isOk()) {
-      Tuple2<String, Term.Bool> t = res6.getOk();
-      return Result.ok(new Tuple2<>(t._1, t._2));
+      Pair<String, Term.Bool> t = res6.getOk();
+      return Result.ok(new Pair<>(t._1, t._2));
     }
 
     var res4 = date(s);
     if (res4.isOk()) {
-      Tuple2<String, Term.Date> t = res4.getOk();
-      return Result.ok(new Tuple2<>(t._1, t._2));
+      Pair<String, Term.Date> t = res4.getOk();
+      return Result.ok(new Pair<>(t._1, t._2));
     }
 
     var res3 = integer(s);
     if (res3.isOk()) {
-      Tuple2<String, Term.Integer> t = res3.getOk();
-      return Result.ok(new Tuple2<>(t._1, t._2));
+      Pair<String, Term.Integer> t = res3.getOk();
+      return Result.ok(new Pair<>(t._1, t._2));
     }
 
     var res8 = bytes(s);
     if (res8.isOk()) {
-      Tuple2<String, Term.Bytes> t = res8.getOk();
-      return Result.ok(new Tuple2<>(t._1, t._2));
+      Pair<String, Term.Bytes> t = res8.getOk();
+      return Result.ok(new Pair<>(t._1, t._2));
     }
 
     return Result.err(new Error(s, "unrecognized value"));
   }
 
-  public static Result<Tuple2<String, Term>, Error> factTerm(String s) {
+  public static Result<Pair<String, Term>, Error> factTerm(String s) {
     if (!s.isEmpty() && s.charAt(0) == '$') {
       return Result.err(new Error(s, "variables are not allowed in facts"));
     }
 
     var res2 = string(s);
     if (res2.isOk()) {
-      Tuple2<String, Term.Str> t = res2.getOk();
-      return Result.ok(new Tuple2<>(t._1, t._2));
+      Pair<String, Term.Str> t = res2.getOk();
+      return Result.ok(new Pair<>(t._1, t._2));
     }
 
     var res7 = set(s);
     if (res7.isOk()) {
-      Tuple2<String, Term.Set> t = res7.getOk();
-      return Result.ok(new Tuple2<>(t._1, t._2));
+      Pair<String, Term.Set> t = res7.getOk();
+      return Result.ok(new Pair<>(t._1, t._2));
     }
 
     var res6 = bool(s);
     if (res6.isOk()) {
-      Tuple2<String, Term.Bool> t = res6.getOk();
-      return Result.ok(new Tuple2<>(t._1, t._2));
+      Pair<String, Term.Bool> t = res6.getOk();
+      return Result.ok(new Pair<>(t._1, t._2));
     }
 
     var res4 = date(s);
     if (res4.isOk()) {
-      Tuple2<String, Term.Date> t = res4.getOk();
-      return Result.ok(new Tuple2<>(t._1, t._2));
+      Pair<String, Term.Date> t = res4.getOk();
+      return Result.ok(new Pair<>(t._1, t._2));
     }
 
     var res3 = integer(s);
     if (res3.isOk()) {
-      Tuple2<String, Term.Integer> t = res3.getOk();
-      return Result.ok(new Tuple2<>(t._1, t._2));
+      Pair<String, Term.Integer> t = res3.getOk();
+      return Result.ok(new Pair<>(t._1, t._2));
     }
 
     var res8 = bytes(s);
     if (res8.isOk()) {
-      Tuple2<String, Term.Bytes> t = res8.getOk();
-      return Result.ok(new Tuple2<>(t._1, t._2));
+      Pair<String, Term.Bytes> t = res8.getOk();
+      return Result.ok(new Pair<>(t._1, t._2));
     }
 
     return Result.err(new Error(s, "unrecognized value"));
   }
 
-  public static Result<Tuple2<String, Term.Str>, Error> string(String s) {
+  public static Result<Pair<String, Term.Str>, Error> string(String s) {
     if (s.charAt(0) != '"') {
       return Result.err(new Error(s, "not a string"));
     }
@@ -697,10 +697,10 @@ public final class Parser {
     String string = s.substring(1, index + 1);
     String remaining = s.substring(index + 2);
 
-    return Result.ok(new Tuple2<String, Term.Str>(remaining, (Term.Str) Utils.string(string)));
+    return Result.ok(new Pair<String, Term.Str>(remaining, (Term.Str) Utils.string(string)));
   }
 
-  public static Result<Tuple2<String, Term.Integer>, Error> integer(String s) {
+  public static Result<Pair<String, Term.Integer>, Error> integer(String s) {
     int index = 0;
     if (s.charAt(0) == '-') {
       index += 1;
@@ -723,34 +723,34 @@ public final class Parser {
     long i = Long.parseLong(s.substring(0, index2));
     String remaining = s.substring(index2);
 
-    return Result.ok(new Tuple2<String, Term.Integer>(remaining, (Term.Integer) Utils.integer(i)));
+    return Result.ok(new Pair<String, Term.Integer>(remaining, (Term.Integer) Utils.integer(i)));
   }
 
-  public static Result<Tuple2<String, Term.Date>, Error> date(String s) {
-    Tuple2<String, String> t = takewhile(s, (c) -> c != ' ' && c != ',' && c != ')' && c != ']');
+  public static Result<Pair<String, Term.Date>, Error> date(String s) {
+    Pair<String, String> t = takewhile(s, (c) -> c != ' ' && c != ',' && c != ')' && c != ']');
 
     try {
       OffsetDateTime d = OffsetDateTime.parse(t._1);
       String remaining = t._2;
-      return Result.ok(new Tuple2<String, Term.Date>(remaining, new Term.Date(d.toEpochSecond())));
+      return Result.ok(new Pair<String, Term.Date>(remaining, new Term.Date(d.toEpochSecond())));
     } catch (DateTimeParseException e) {
       return Result.err(new Error(s, "not a date"));
     }
   }
 
-  public static Result<Tuple2<String, Term.Variable>, Error> variable(String s) {
+  public static Result<Pair<String, Term.Variable>, Error> variable(String s) {
     if (s.charAt(0) != '$') {
       return Result.err(new Error(s, "not a variable"));
     }
 
-    Tuple2<String, String> t =
+    Pair<String, String> t =
         takewhile(
             s.substring(1), (c) -> Character.isAlphabetic(c) || Character.isDigit(c) || c == '_');
 
-    return Result.ok(new Tuple2<String, Term.Variable>(t._2, (Term.Variable) Utils.var(t._1)));
+    return Result.ok(new Pair<String, Term.Variable>(t._2, (Term.Variable) Utils.var(t._1)));
   }
 
-  public static Result<Tuple2<String, Term.Bool>, Error> bool(String s) {
+  public static Result<Pair<String, Term.Bool>, Error> bool(String s) {
     boolean b;
     if (s.startsWith("true")) {
       b = true;
@@ -762,10 +762,10 @@ public final class Parser {
       return Result.err(new Error(s, "not a boolean"));
     }
 
-    return Result.ok(new Tuple2<>(s, new Term.Bool(b)));
+    return Result.ok(new Pair<>(s, new Term.Bool(b)));
   }
 
-  public static Result<Tuple2<String, Term.Set>, Error> set(String s) {
+  public static Result<Pair<String, Term.Set>, Error> set(String s) {
     if (s.isEmpty() || s.charAt(0) != '[') {
       return Result.err(new Error(s, "not a set"));
     }
@@ -782,7 +782,7 @@ public final class Parser {
         break;
       }
 
-      Tuple2<String, Term> t = res.getOk();
+      Pair<String, Term> t = res.getOk();
 
       if (t._2 instanceof Term.Variable) {
         return Result.err(new Error(s, "sets cannot contain variables"));
@@ -807,19 +807,19 @@ public final class Parser {
 
     String remaining = s.substring(1);
 
-    return Result.ok(new Tuple2<>(remaining, new Term.Set(terms)));
+    return Result.ok(new Pair<>(remaining, new Term.Set(terms)));
   }
 
-  public static Result<Tuple2<String, Term.Bytes>, Error> bytes(String s) {
+  public static Result<Pair<String, Term.Bytes>, Error> bytes(String s) {
     if (!s.startsWith("hex:")) {
       return Result.err(new Error(s, "not a bytes array"));
     }
     s = s.substring(4);
-    Tuple2<String, byte[]> t = hex(s);
-    return Result.ok(new Tuple2<>(t._1, new Term.Bytes(t._2)));
+    Pair<String, byte[]> t = hex(s);
+    return Result.ok(new Pair<>(t._1, new Term.Bytes(t._2)));
   }
 
-  public static Tuple2<String, byte[]> hex(String s) {
+  public static Pair<String, byte[]> hex(String s) {
     int index = 0;
     for (int i = 0; i < s.length(); i++) {
       char c = s.charAt(i);
@@ -833,10 +833,10 @@ public final class Parser {
     String hex = s.substring(0, index);
     byte[] bytes = Utils.hexStringToByteArray(hex);
     s = s.substring(index);
-    return new Tuple2<>(s, bytes);
+    return new Pair<>(s, bytes);
   }
 
-  public static Result<Tuple2<String, Expression>, Error> expression(String s) {
+  public static Result<Pair<String, Expression>, Error> expression(String s) {
     return ExpressionParser.parse(s);
   }
 
@@ -854,7 +854,7 @@ public final class Parser {
     return s.substring(index);
   }
 
-  public static Tuple2<String, String> takewhile(String s, Function<Character, Boolean> f) {
+  public static Pair<String, String> takewhile(String s, Function<Character, Boolean> f) {
     int index = s.length();
     for (int i = 0; i < s.length(); i++) {
       Character c = s.charAt(i);
@@ -865,7 +865,7 @@ public final class Parser {
       }
     }
 
-    return new Tuple2<>(s.substring(0, index), s.substring(index));
+    return new Pair<>(s.substring(0, index), s.substring(index));
   }
 
   public static String removeCommentsAndWhitespaces(String s) {
@@ -884,12 +884,12 @@ public final class Parser {
         // Find the end of the multiline comment
         remaining = remaining.substring(2); // Skip "/*"
         String finalRemaining = remaining;
-        Tuple2<String, String> split = takewhile(remaining, c -> !finalRemaining.startsWith("*/"));
+        Pair<String, String> split = takewhile(remaining, c -> !finalRemaining.startsWith("*/"));
         remaining = split._2.length() > 2 ? split._2.substring(2) : ""; // Skip "*/"
       } else if (remaining.startsWith("//")) {
         // Find the end of the single-line comment
         remaining = remaining.substring(2); // Skip "//"
-        Tuple2<String, String> split = takewhile(remaining, c -> c != '\n' && c != '\r');
+        Pair<String, String> split = takewhile(remaining, c -> c != '\n' && c != '\r');
         remaining = split._2;
         if (!remaining.isEmpty()) {
           result.append(remaining.charAt(0)); // Preserve line break
@@ -898,7 +898,7 @@ public final class Parser {
       } else {
         // Take non-comment text until the next comment or end of string
         String finalRemaining = remaining;
-        Tuple2<String, String> split =
+        Pair<String, String> split =
             takewhile(
                 remaining,
                 c -> !finalRemaining.startsWith("/*") && !finalRemaining.startsWith("//"));

--- a/src/main/java/org/eclipse/biscuit/token/format/Proof.java
+++ b/src/main/java/org/eclipse/biscuit/token/format/Proof.java
@@ -5,7 +5,7 @@
 
 package org.eclipse.biscuit.token.format;
 
-import io.vavr.control.Option;
+import java.util.Optional;
 import org.eclipse.biscuit.crypto.KeyPair;
 
 /** Sum type for Proof NextSecret or FinalSignature. */
@@ -29,7 +29,7 @@ interface Proof {
    *
    * @return the signature if sealed or none
    */
-  Option<byte[]> getSignature();
+  Optional<byte[]> getSignature();
 
   /** NextSecret with a keypair. */
   final class NextSecret implements Proof {
@@ -56,8 +56,8 @@ interface Proof {
     }
 
     @Override
-    public Option<byte[]> getSignature() {
-      return Option.none();
+    public Optional<byte[]> getSignature() {
+      return Optional.empty();
     }
   }
 
@@ -84,8 +84,8 @@ interface Proof {
     }
 
     @Override
-    public Option<byte[]> getSignature() {
-      return Option.some(this.signature);
+    public Optional<byte[]> getSignature() {
+      return Optional.of(this.signature);
     }
   }
 }

--- a/src/main/java/org/eclipse/biscuit/token/format/SerializedBiscuit.java
+++ b/src/main/java/org/eclipse/biscuit/token/format/SerializedBiscuit.java
@@ -8,7 +8,6 @@ package org.eclipse.biscuit.token.format;
 import biscuit.format.schema.Schema;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-import io.vavr.Tuple2;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.security.InvalidKeyException;
@@ -22,6 +21,7 @@ import org.eclipse.biscuit.crypto.BlockSignatureBuffer;
 import org.eclipse.biscuit.crypto.KeyDelegate;
 import org.eclipse.biscuit.crypto.KeyPair;
 import org.eclipse.biscuit.crypto.PublicKey;
+import org.eclipse.biscuit.datalog.Pair;
 import org.eclipse.biscuit.datalog.SymbolTable;
 import org.eclipse.biscuit.error.Error;
 import org.eclipse.biscuit.error.Result;
@@ -489,7 +489,7 @@ public final class SerializedBiscuit {
     return Result.ok(signedBlock.getKey());
   }
 
-  public Tuple2<Block, ArrayList<Block>> extractBlocks(SymbolTable symbolTable) throws Error {
+  public Pair<Block, ArrayList<Block>> extractBlocks(SymbolTable symbolTable) throws Error {
     ArrayList<Optional<org.eclipse.biscuit.crypto.PublicKey>> blockExternalKeys = new ArrayList<>();
     var authRes = Block.fromBytes(this.authority.getBlock(), Optional.empty());
     if (authRes.isErr()) {
@@ -534,7 +534,7 @@ public final class SerializedBiscuit {
       blocks.add(block);
     }
 
-    return new Tuple2<>(authority, blocks);
+    return new Pair<>(authority, blocks);
   }
 
   public Result<Void, Error> seal()

--- a/src/main/java/org/eclipse/biscuit/token/format/SignedBlock.java
+++ b/src/main/java/org/eclipse/biscuit/token/format/SignedBlock.java
@@ -5,21 +5,21 @@
 
 package org.eclipse.biscuit.token.format;
 
-import io.vavr.control.Option;
+import java.util.Optional;
 import org.eclipse.biscuit.crypto.PublicKey;
 
 public class SignedBlock {
   private byte[] block;
   private PublicKey key;
   private byte[] signature;
-  private Option<ExternalSignature> externalSignature;
+  private Optional<ExternalSignature> externalSignature;
   private int version;
 
   public SignedBlock(
       byte[] block,
       PublicKey key,
       byte[] signature,
-      Option<ExternalSignature> externalSignature,
+      Optional<ExternalSignature> externalSignature,
       int version) {
     this.block = block;
     this.key = key;
@@ -40,7 +40,7 @@ public class SignedBlock {
     return signature;
   }
 
-  public Option<ExternalSignature> getExternalSignature() {
+  public Optional<ExternalSignature> getExternalSignature() {
     return externalSignature;
   }
 

--- a/src/test/java/org/eclipse/biscuit/builder/parser/ParserTest.java
+++ b/src/test/java/org/eclipse/biscuit/builder/parser/ParserTest.java
@@ -11,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import biscuit.format.schema.Schema;
 import io.vavr.Tuple2;
-import io.vavr.control.Either;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -454,8 +453,8 @@ class ParserTest {
     String l4 = "check if rule1(2)";
     String toParse = String.join(";", Arrays.asList(l1, l2, l3, l4));
 
-    Either<Map<Integer, List<Error>>, Block> output = Parser.datalog(1, toParse);
-    assertTrue(output.isRight());
+    var output = Parser.datalog(1, toParse);
+    assertTrue(output.isOk());
 
     Block validBlock = new Block();
     validBlock.addFact(l1);
@@ -463,7 +462,7 @@ class ParserTest {
     validBlock.addRule(l3);
     validBlock.addCheck(l4);
 
-    output.forEach(block -> assertEquals(block, validBlock));
+    assertEquals(output.getOk(), validBlock);
   }
 
   @Test
@@ -471,13 +470,13 @@ class ParserTest {
     String l1 = "check if [2, 3].union([2])";
     String toParse = String.join(";", List.of(l1));
 
-    Either<Map<Integer, List<Error>>, Block> output = Parser.datalog(1, toParse);
-    assertTrue(output.isRight());
+    var output = Parser.datalog(1, toParse);
+    assertTrue(output.isOk());
 
     Block validBlock = new Block();
     validBlock.addCheck(l1);
 
-    output.forEach(block -> assertEquals(block, validBlock));
+    assertEquals(output.getOk(), validBlock);
   }
 
   @Test
@@ -486,13 +485,13 @@ class ParserTest {
         "check if [2019-12-04T09:46:41Z, 2020-12-04T09:46:41Z].contains(2020-12-04T09:46:41Z)";
     String toParse = String.join(";", List.of(l1));
 
-    Either<Map<Integer, List<Error>>, Block> output = Parser.datalog(1, toParse);
-    assertTrue(output.isRight());
+    var output = Parser.datalog(1, toParse);
+    assertTrue(output.isOk());
 
     Block validBlock = new Block();
     validBlock.addCheck(l1);
 
-    output.forEach(block -> assertEquals(block, validBlock));
+    assertEquals(output.getOk(), validBlock);
   }
 
   @Test
@@ -501,8 +500,7 @@ class ParserTest {
     String l2 = "check fact(1)"; // typo missing "if"
     String toParse = String.join(";", Arrays.asList(l1, l2));
 
-    Either<Map<Integer, List<Error>>, Block> output = Parser.datalog(1, toParse);
-    assertTrue(output.isLeft());
+    assertTrue(Parser.datalog(1, toParse).isErr());
   }
 
   @Test
@@ -519,7 +517,6 @@ class ParserTest {
     String l8 = "comment */";
     String toParse = String.join("", Arrays.asList(l0, l1, l2, l3, l4, l5, l6, l7, l8));
 
-    Either<Map<Integer, List<Error>>, Block> output = Parser.datalog(1, toParse);
-    assertTrue(output.isRight());
+    assertTrue(Parser.datalog(1, toParse).isOk());
   }
 }

--- a/src/test/java/org/eclipse/biscuit/builder/parser/ParserTest.java
+++ b/src/test/java/org/eclipse/biscuit/builder/parser/ParserTest.java
@@ -10,7 +10,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import biscuit.format.schema.Schema;
-import io.vavr.Tuple2;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -18,6 +17,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import org.eclipse.biscuit.crypto.PublicKey;
+import org.eclipse.biscuit.datalog.Pair;
 import org.eclipse.biscuit.datalog.SymbolTable;
 import org.eclipse.biscuit.datalog.TemporarySymbolTable;
 import org.eclipse.biscuit.datalog.expressions.Op;
@@ -39,34 +39,34 @@ class ParserTest {
   @Test
   void testName() {
     var res = Parser.name("operation(read)");
-    assertEquals(Result.ok(new Tuple2<>("(read)", "operation")), res);
+    assertEquals(Result.ok(new Pair<>("(read)", "operation")), res);
   }
 
   @Test
   void testString() {
     var res = Parser.string("\"file1 a hello - 123_\"");
-    assertEquals(Result.ok(new Tuple2<>("", (Term.Str) Utils.string("file1 a hello - 123_"))), res);
+    assertEquals(Result.ok(new Pair<>("", (Term.Str) Utils.string("file1 a hello - 123_"))), res);
   }
 
   @Test
   void testInteger() {
     var res = Parser.integer("123");
-    assertEquals(Result.ok(new Tuple2<>("", (Term.Integer) Utils.integer(123))), res);
+    assertEquals(Result.ok(new Pair<>("", (Term.Integer) Utils.integer(123))), res);
 
     var res2 = Parser.integer("-42");
-    assertEquals(Result.ok(new Tuple2<>("", (Term.Integer) Utils.integer(-42))), res2);
+    assertEquals(Result.ok(new Pair<>("", (Term.Integer) Utils.integer(-42))), res2);
   }
 
   @Test
   void testDate() {
     var res = Parser.date("2019-12-02T13:49:53Z,");
-    assertEquals(Result.ok(new Tuple2<>(",", new Term.Date(1575294593))), res);
+    assertEquals(Result.ok(new Pair<>(",", new Term.Date(1575294593))), res);
   }
 
   @Test
   void testVariable() {
     var res = Parser.variable("$name");
-    assertEquals(Result.ok(new Tuple2<>("", (Term.Variable) Utils.var("name"))), res);
+    assertEquals(Result.ok(new Pair<>("", (Term.Variable) Utils.var("name"))), res);
   }
 
   @Test
@@ -74,7 +74,7 @@ class ParserTest {
     var res = Parser.fact("right( \"file1\", \"read\" )");
     assertEquals(
         Result.ok(
-            new Tuple2<>(
+            new Pair<>(
                 "", Utils.fact("right", Arrays.asList(Utils.string("file1"), Utils.str("read"))))),
         res);
 
@@ -83,12 +83,12 @@ class ParserTest {
 
     var res3 = Parser.fact("date(2019-12-02T13:49:53Z)");
     assertEquals(
-        Result.ok(new Tuple2<>("", Utils.fact("date", List.of(new Term.Date(1575294593))))), res3);
+        Result.ok(new Pair<>("", Utils.fact("date", List.of(new Term.Date(1575294593))))), res3);
 
     var res4 = Parser.fact("n1:right( \"file1\", \"read\" )");
     assertEquals(
         Result.ok(
-            new Tuple2<>(
+            new Pair<>(
                 "",
                 Utils.fact("n1:right", Arrays.asList(Utils.string("file1"), Utils.str("read"))))),
         res4);
@@ -99,7 +99,7 @@ class ParserTest {
     var res = Parser.rule("right($resource, \"read\") <- resource($resource), operation(\"read\")");
     assertEquals(
         Result.ok(
-            new Tuple2<>(
+            new Pair<>(
                 "",
                 Utils.rule(
                     "right",
@@ -117,7 +117,7 @@ class ParserTest {
             "valid_date(\"file1\") <- time($0 ), resource( \"file1\"), $0 <= 2019-12-04T09:46:41Z");
     assertEquals(
         Result.ok(
-            new Tuple2<>(
+            new Pair<>(
                 "",
                 Utils.constrainedRule(
                     "valid_date",
@@ -140,7 +140,7 @@ class ParserTest {
             "valid_date(\"file1\") <- time($0 ), $0 <= 2019-12-04T09:46:41Z, resource(\"file1\")");
     assertEquals(
         Result.ok(
-            new Tuple2<>(
+            new Pair<>(
                 "",
                 Utils.constrainedRule(
                     "valid_date",
@@ -162,7 +162,7 @@ class ParserTest {
 
     assertEquals(
         Result.ok(
-            new Tuple2<>(
+            new Pair<>(
                 "",
                 new Expression.Binary(
                     Expression.Op.Contains,
@@ -186,7 +186,7 @@ class ParserTest {
 
     assertEquals(
         Result.ok(
-            new Tuple2<>(
+            new Pair<>(
                 "",
                 new Expression.Binary(
                     Expression.Op.Equal,
@@ -214,7 +214,7 @@ class ParserTest {
     var res = Parser.check("check if !false && true");
     assertEquals(
         Result.ok(
-            new Tuple2<>(
+            new Pair<>(
                 "",
                 Utils.check(
                     Utils.constrainedRule(
@@ -261,7 +261,7 @@ class ParserTest {
                         Schema.PublicKey.Algorithm.Ed25519,
                         "6e9e6d5a75cf0c0e87ec1256b4dfed0ca3ba452912d213fcc70f8516583db9db")),
                 Scope.authority()));
-    assertEquals(Result.ok(new Tuple2<>("", refRule)), res);
+    assertEquals(Result.ok(new Pair<>("", refRule)), res);
   }
 
   @Test
@@ -269,7 +269,7 @@ class ParserTest {
     var res = Parser.check("check if resource($0), operation(\"read\") or admin()");
     assertEquals(
         Result.ok(
-            new Tuple2<>(
+            new Pair<>(
                 "",
                 new Check(
                     ONE,
@@ -292,12 +292,12 @@ class ParserTest {
     var res = Parser.expression(" -1 ");
 
     assertEquals(
-        new Tuple2<String, Expression>("", new Expression.Value(Utils.integer(-1))), res.getOk());
+        new Pair<String, Expression>("", new Expression.Value(Utils.integer(-1))), res.getOk());
 
     var res2 = Parser.expression(" $0 <= 2019-12-04T09:46:41+00:00");
 
     assertEquals(
-        new Tuple2<String, Expression>(
+        new Pair<String, Expression>(
             "",
             new Expression.Binary(
                 Expression.Op.LessOrEqual,
@@ -309,7 +309,7 @@ class ParserTest {
 
     assertEquals(
         Result.ok(
-            new Tuple2<String, Expression>(
+            new Pair<String, Expression>(
                 "",
                 new Expression.Binary(
                     Expression.Op.LessThan,
@@ -335,7 +335,7 @@ class ParserTest {
 
     assertEquals(
         Result.ok(
-            new Tuple2<String, Expression>(
+            new Pair<String, Expression>(
                 "",
                 new Expression.Binary(
                     Expression.Op.And,
@@ -360,7 +360,7 @@ class ParserTest {
 
     assertEquals(
         Result.ok(
-            new Tuple2<String, Expression>(
+            new Pair<String, Expression>(
                 "",
                 new Expression.Binary(
                     Expression.Op.Contains,
@@ -375,7 +375,7 @@ class ParserTest {
 
     assertEquals(
         Result.ok(
-            new Tuple2<String, Expression>(
+            new Pair<String, Expression>(
                 "",
                 new Expression.Binary(
                     Expression.Op.Add,
@@ -409,7 +409,7 @@ class ParserTest {
 
     assertEquals(
         Result.ok(
-            new Tuple2<String, Expression>(
+            new Pair<String, Expression>(
                 "",
                 new Expression.Binary(
                     Expression.Op.Mul,

--- a/src/test/java/org/eclipse/biscuit/crypto/SignatureTest.java
+++ b/src/test/java/org/eclipse/biscuit/crypto/SignatureTest.java
@@ -5,7 +5,6 @@
 
 package org.eclipse.biscuit.crypto;
 
-import static io.vavr.API.Right;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -17,6 +16,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.SignatureException;
 import org.eclipse.biscuit.error.Error;
+import org.eclipse.biscuit.error.Result;
 import org.eclipse.biscuit.token.Biscuit;
 import org.junit.jupiter.api.Test;
 
@@ -126,17 +126,17 @@ public class SignatureTest {
     System.out.println("keypair2 public: " + keypair2.getPublicKey().toHex());
 
     Token token1 = new Token(root, message1.getBytes(), keypair2);
-    assertEquals(Right(null), token1.verify(root.getPublicKey()));
+    assertEquals(Result.ok(null), token1.verify(root.getPublicKey()));
 
     String message2 = "world";
     KeyPair keypair3 = KeyPair.generate(algorithm, rng);
     Token token2 = token1.append(keypair3, message2.getBytes());
-    assertEquals(Right(null), token2.verify(root.getPublicKey()));
+    assertEquals(Result.ok(null), token2.verify(root.getPublicKey()));
 
     String message3 = "!!";
     KeyPair keypair4 = KeyPair.generate(algorithm, rng);
     Token token3 = token2.append(keypair4, message3.getBytes());
-    assertEquals(Right(null), token3.verify(root.getPublicKey()));
+    assertEquals(Result.ok(null), token3.verify(root.getPublicKey()));
   }
 
   private static void prGenSigKeys(Schema.PublicKey.Algorithm algorithm) throws Error.FormatError {

--- a/src/test/java/org/eclipse/biscuit/token/BiscuitTest.java
+++ b/src/test/java/org/eclipse/biscuit/token/BiscuitTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import biscuit.format.schema.Schema;
-import io.vavr.control.Option;
 import io.vavr.control.Try;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -30,6 +29,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 import org.eclipse.biscuit.crypto.KeyDelegate;
 import org.eclipse.biscuit.crypto.KeyPair;
 import org.eclipse.biscuit.crypto.PublicKey;
@@ -702,8 +702,8 @@ public class BiscuitTest {
                   data,
                   new KeyDelegate() {
                     @Override
-                    public Option<PublicKey> getRootKey(Option<Integer> keyId) {
-                      return Option.none();
+                    public Optional<PublicKey> getRootKey(Optional<Integer> keyId) {
+                      return Optional.empty();
                     }
                   });
         });
@@ -716,10 +716,10 @@ public class BiscuitTest {
                   data,
                   new KeyDelegate() {
                     @Override
-                    public Option<PublicKey> getRootKey(Option<Integer> keyId) {
+                    public Optional<PublicKey> getRootKey(Optional<Integer> keyId) {
 
                       KeyPair root = KeyPair.generate(Schema.PublicKey.Algorithm.Ed25519, rng);
-                      return Option.some(root.getPublicKey());
+                      return Optional.of(root.getPublicKey());
                     }
                   });
         });
@@ -729,11 +729,11 @@ public class BiscuitTest {
             data,
             new KeyDelegate() {
               @Override
-              public Option<PublicKey> getRootKey(Option<Integer> keyId) {
+              public Optional<PublicKey> getRootKey(Optional<Integer> keyId) {
                 if (keyId.get() == 1) {
-                  return Option.some(root.getPublicKey());
+                  return Optional.of(root.getPublicKey());
                 } else {
-                  return Option.none();
+                  return Optional.empty();
                 }
               }
             });

--- a/src/test/java/org/eclipse/biscuit/token/BiscuitTest.java
+++ b/src/test/java/org/eclipse/biscuit/token/BiscuitTest.java
@@ -15,11 +15,9 @@ import static org.eclipse.biscuit.token.builder.Utils.str;
 import static org.eclipse.biscuit.token.builder.Utils.var;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import biscuit.format.schema.Schema;
-import io.vavr.control.Try;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -38,6 +36,7 @@ import org.eclipse.biscuit.error.Error;
 import org.eclipse.biscuit.error.FailedCheck;
 import org.eclipse.biscuit.error.LogicError;
 import org.eclipse.biscuit.token.builder.Block;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class BiscuitTest {
@@ -332,17 +331,15 @@ public class BiscuitTest {
     v3.addFact("resource(\"/folder2/file3\")");
     v3.addFact("operation(\"read\")");
 
-    Try<Long> res = Try.of(() -> v3.authorize());
+    Assertions.assertThrows(Error.class, v3::authorize);
     System.out.println(v3.formatWorld());
-
-    assertTrue(res.isFailure());
 
     Authorizer v4 = v1.clone();
 
     v4.addFact("resource(\"/folder2/file1\")");
     v4.addFact("operation(\"write\")");
 
-    Error e = (Error) Try.of(() -> v4.authorize()).getCause();
+    var e = Assertions.assertThrows(Error.class, v4::authorize);
 
     System.out.println(v4.formatWorld());
     for (FailedCheck f : e.getFailedChecks().get()) {
@@ -402,7 +399,7 @@ public class BiscuitTest {
     v1.addFact("resource(\"/folder2/file1\")");
     v1.addFact("operation(\"write\")");
 
-    assertTrue(Try.of(() -> v1.authorize()).isFailure());
+    assertThrows(Error.class, v1::authorize);
   }
 
   @Test

--- a/src/test/java/org/eclipse/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/eclipse/biscuit/token/SamplesTest.java
@@ -333,26 +333,13 @@ class SamplesTest {
 
     public List<PublicKey> getPublicKeys() {
       return this.publicKeys.stream()
-          .map(
-              pk ->
-                  Parser.publicKey(pk)
-                      .fold(
-                          e -> {
-                            throw new IllegalArgumentException(e.toString());
-                          },
-                          r -> r._2))
+          .map(pk -> Parser.publicKey(pk).getOk()._2)
           .collect(Collectors.toList());
     }
 
     public Optional<PublicKey> getExternalKey() {
       if (this.externalKey != null) {
-        PublicKey externalKey =
-            Parser.publicKey(this.externalKey)
-                .fold(
-                    e -> {
-                      throw new IllegalArgumentException(e.toString());
-                    },
-                    r -> r._2);
+        PublicKey externalKey = Parser.publicKey(this.externalKey).getOk()._2;
         return Optional.of(externalKey);
       } else {
         return Optional.empty();

--- a/src/test/java/org/eclipse/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/eclipse/biscuit/token/SamplesTest.java
@@ -16,7 +16,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import io.vavr.Tuple2;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -38,6 +37,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.biscuit.crypto.KeyPair;
 import org.eclipse.biscuit.crypto.PublicKey;
+import org.eclipse.biscuit.datalog.Pair;
 import org.eclipse.biscuit.datalog.RunLimits;
 import org.eclipse.biscuit.datalog.SymbolTable;
 import org.eclipse.biscuit.error.Error;
@@ -436,7 +436,7 @@ class SamplesTest {
       this.checks =
           authorizer.getChecks().stream()
               .map(
-                  (Tuple2<Long, List<Check>> t) -> {
+                  (Pair<Long, List<Check>> t) -> {
                     List<String> checks1 =
                         t._2.stream().map(c -> c.toString()).collect(Collectors.toList());
                     Collections.sort(checks1);

--- a/src/test/java/org/eclipse/biscuit/token/SamplesTest.java
+++ b/src/test/java/org/eclipse/biscuit/token/SamplesTest.java
@@ -18,7 +18,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.vavr.Tuple2;
 import io.vavr.control.Either;
-import io.vavr.control.Option;
 import io.vavr.control.Try;
 import java.io.BufferedInputStream;
 import java.io.IOException;
@@ -36,6 +35,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.biscuit.crypto.KeyPair;
@@ -74,10 +74,10 @@ class SamplesTest {
 
   void compareBlocks(KeyPair root, List<Block> sampleBlocks, Biscuit token) throws Error {
     assertEquals(sampleBlocks.size(), 1 + token.blocks.size());
-    Option<Biscuit> sampleToken = Option.none();
+    Optional<Biscuit> sampleToken = Optional.empty();
     Biscuit b =
         compareBlock(root, sampleToken, 0, sampleBlocks.get(0), token.authority, token.symbolTable);
-    sampleToken = Option.some(b);
+    sampleToken = Optional.of(b);
 
     for (int i = 0; i < token.blocks.size(); i++) {
       b =
@@ -88,19 +88,19 @@ class SamplesTest {
               sampleBlocks.get(i + 1),
               token.blocks.get(i),
               token.symbolTable);
-      sampleToken = Option.some(b);
+      sampleToken = Optional.of(b);
     }
   }
 
   Biscuit compareBlock(
       KeyPair root,
-      Option<Biscuit> sampleToken,
+      Optional<Biscuit> sampleToken,
       long sampleBlockIndex,
       Block sampleBlock,
       org.eclipse.biscuit.token.Block tokenBlock,
       SymbolTable tokenSymbols)
       throws Error {
-    Option<PublicKey> sampleExternalKey = sampleBlock.getExternalKey();
+    Optional<PublicKey> sampleExternalKey = sampleBlock.getExternalKey();
     List<PublicKey> samplePublicKeys = sampleBlock.getPublicKeys();
     String sampleDatalog = sampleBlock.getCode().replace("\"", "\\\"");
 
@@ -115,10 +115,10 @@ class SamplesTest {
     }
 
     Biscuit newSampleToken;
-    if (!sampleToken.isDefined()) {
+    if (sampleToken.isEmpty()) {
       org.eclipse.biscuit.token.builder.Biscuit builder =
           new org.eclipse.biscuit.token.builder.Biscuit(
-              new SecureRandom(), root, Option.none(), outputSample.get());
+              new SecureRandom(), root, Optional.empty(), outputSample.get());
       newSampleToken = builder.build();
     } else {
       Biscuit s = sampleToken.get();
@@ -126,7 +126,7 @@ class SamplesTest {
     }
 
     org.eclipse.biscuit.token.Block generatedSampleBlock;
-    if (!sampleToken.isDefined()) {
+    if (sampleToken.isEmpty()) {
       generatedSampleBlock = newSampleToken.authority;
     } else {
       generatedSampleBlock = newSampleToken.blocks.get((int) sampleBlockIndex - 1);
@@ -344,7 +344,7 @@ class SamplesTest {
           .collect(Collectors.toList());
     }
 
-    public Option<PublicKey> getExternalKey() {
+    public Optional<PublicKey> getExternalKey() {
       if (this.externalKey != null) {
         PublicKey externalKey =
             Parser.publicKey(this.externalKey)
@@ -353,9 +353,9 @@ class SamplesTest {
                       throw new IllegalArgumentException(e.toString());
                     },
                     r -> r._2);
-        return Option.of(externalKey);
+        return Optional.of(externalKey);
       } else {
-        return Option.none();
+        return Optional.empty();
       }
     }
   }

--- a/src/test/java/org/eclipse/biscuit/token/ThirdPartyTest.java
+++ b/src/test/java/org/eclipse/biscuit/token/ThirdPartyTest.java
@@ -8,7 +8,6 @@ package org.eclipse.biscuit.token;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import biscuit.format.schema.Schema;
-import io.vavr.control.Option;
 import java.io.IOException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
@@ -17,6 +16,7 @@ import java.security.SignatureException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.eclipse.biscuit.crypto.KeyPair;
 import org.eclipse.biscuit.datalog.RunLimits;
 import org.eclipse.biscuit.error.Error;
@@ -69,9 +69,9 @@ public class ThirdPartyTest {
     Biscuit deser = Biscuit.fromBytes(data, root.getPublicKey());
     assertEquals(b2.print(), deser.print());
     assertEquals(
-        b2.externalPublicKeys(), List.of(Option.none(), Option.of(external.getPublicKey())));
-    assertEquals(Option.none(), b2.blockExternalKey(0));
-    assertEquals(Option.of(external.getPublicKey()), b2.blockExternalKey(1));
+        b2.externalPublicKeys(), List.of(Optional.empty(), Optional.of(external.getPublicKey())));
+    assertEquals(Optional.empty(), b2.blockExternalKey(0));
+    assertEquals(Optional.of(external.getPublicKey()), b2.blockExternalKey(1));
 
     System.out.println("will check the token for resource=file1");
     Authorizer authorizer = deser.authorizer();

--- a/src/test/java/org/eclipse/biscuit/token/ThirdPartyTest.java
+++ b/src/test/java/org/eclipse/biscuit/token/ThirdPartyTest.java
@@ -58,7 +58,7 @@ public class ThirdPartyTest {
     builder.addFact("group(\"admin\")");
     builder.addCheck("check if resource(\"file1\")");
 
-    ThirdPartyBlockContents blockResponse = request.createBlock(external, builder).get();
+    ThirdPartyBlockContents blockResponse = request.createBlock(external, builder).getOk();
     byte[] resb = blockResponse.toBytes();
     ThirdPartyBlockContents resdeser = ThirdPartyBlockContents.fromBytes(resb);
     assertEquals(blockResponse, resdeser);
@@ -133,7 +133,7 @@ public class ThirdPartyTest {
     builder.addFact("first(\"admin\")");
     builder.addFact("second(\"A\")");
     builder.addCheck("check if third(3) trusting ed25519/" + external2.getPublicKey().toHex());
-    ThirdPartyBlockContents blockResponse = request1.createBlock(external1, builder).get();
+    ThirdPartyBlockContents blockResponse = request1.createBlock(external1, builder).getOk();
     Biscuit b2 = b1.appendThirdPartyBlock(external1.getPublicKey(), blockResponse);
     byte[] data = b2.serialize();
     Biscuit deser2 = Biscuit.fromBytes(data, root.getPublicKey());
@@ -148,7 +148,7 @@ public class ThirdPartyTest {
             + external3.getPublicKey().toHex()
             + ", ed25519/"
             + external1.getPublicKey().toHex());
-    ThirdPartyBlockContents blockResponse2 = request2.createBlock(external2, builder2).get();
+    ThirdPartyBlockContents blockResponse2 = request2.createBlock(external2, builder2).getOk();
     Biscuit b3 = deser2.appendThirdPartyBlock(external2.getPublicKey(), blockResponse2);
     byte[] data2 = b3.serialize();
     Biscuit deser3 = Biscuit.fromBytes(data2, root.getPublicKey());
@@ -159,7 +159,7 @@ public class ThirdPartyTest {
     Block builder3 = new Block();
     builder3.addFact("fourth(1)");
     builder3.addCheck("check if resource(\"file1\")");
-    ThirdPartyBlockContents blockResponse3 = request3.createBlock(external1, builder3).get();
+    ThirdPartyBlockContents blockResponse3 = request3.createBlock(external1, builder3).getOk();
     Biscuit b4 = deser3.appendThirdPartyBlock(external1.getPublicKey(), blockResponse3);
     byte[] data3 = b4.serialize();
     Biscuit deser4 = Biscuit.fromBytes(data3, root.getPublicKey());
@@ -222,7 +222,7 @@ public class ThirdPartyTest {
     builder.addCheck("check if resource(\"file1\")");
     builder.addCheck("check if right(\"read\")");
 
-    ThirdPartyBlockContents blockResponse = request.createBlock(external, builder).get();
+    ThirdPartyBlockContents blockResponse = request.createBlock(external, builder).getOk();
     Biscuit b2 = b1.appendThirdPartyBlock(external.getPublicKey(), blockResponse);
 
     byte[] data = b2.serialize();


### PR DESCRIPTION
This PR is best reviewed commit-by-commit. At a high level, it comprises of two major changes:

1. Replace `gson` library with the more modern and maintained `jackson`.
2. Remove `vavr` dependency, replacing with builtins and custom types where necessary.